### PR TITLE
Add fish mini-games: FishEat (desktop) + SeaFloorHop (mobile)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,8 @@ import { skillsData } from "@/data/skills";
 import { toolsData } from "@/data/tools";
 import { experienceData } from "@/data/experience";
 import Image from "next/image";
+import FishEat from "@/components/FishEat";
+import SeaFloorHop from "@/components/SeaFloorHop";
 
 export default function HomePage() {
   return (
@@ -163,7 +165,8 @@ export default function HomePage() {
           </div>
 
           {/* Contact */}
-          <div className="text-center py-16 border-t border-white/10">
+          <div className="text-center pt-16 pb-20 border-t border-white/10">
+            <DepthLabel depth="~3800m" />
             <p className="text-white/40 text-sm tracking-widest uppercase mb-3">— Abyss reached —</p>
             <h3 className="text-3xl font-bold text-white mb-4">Let&apos;s work together</h3>
             <p className="text-white/60 mb-8 max-w-md mx-auto">You&apos;ve made it to the bottom. If you&apos;re still here, we should probably talk.</p>
@@ -171,9 +174,25 @@ export default function HomePage() {
               Get in touch
             </a>
           </div>
+
+          {/* Fish eat fish — desktop only */}
+          <div className="hidden md:block border-t border-white/10 pt-8 pb-2">
+            <p className="text-white/30 text-xs text-center tracking-widest uppercase mb-6">Eat or be eaten</p>
+            <FishEat />
+          </div>
+
+          {/* Sea floor hop — mobile only */}
+          <div className="block md:hidden border-t border-white/10 pt-8 pb-2">
+            <p className="text-white/30 text-xs text-center tracking-widest uppercase mb-6">Hop or be squished</p>
+            <SeaFloorHop />
+          </div>
         </DepthSection>
 
       </main>
+
+      {/* <footer className="relative z-10">
+        <CoralSlalom />
+      </footer> */}
     </>
   );
 }

--- a/src/components/CoralSlalom.tsx
+++ b/src/components/CoralSlalom.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+const H             = 130;
+const FISH_X        = 80;
+const FISH_R        = 10;
+const LERP          = 0.10;       // how fast fish follows cursor (0–1)
+const INIT_SPEED    = 2.2;
+const SPEED_INC     = 0.00007;
+const PIPE_W        = 22;
+const GAP           = 60;
+const PIPE_INTERVAL = 240;
+const PIPE_MIN_TOP  = 18;
+const SCORE_INTERVAL = 60;        // frames per score point
+
+type GameState = "idle" | "playing" | "dead";
+type Pipe = { x: number; gapY: number };
+
+// ── Fish drawing ──────────────────────────────────────────────────────────────
+function drawFish(ctx: CanvasRenderingContext2D, x: number, y: number, vy: number, alpha = 1) {
+  ctx.save();
+  ctx.globalAlpha = alpha;
+  ctx.translate(x, y);
+  ctx.rotate(Math.max(-0.45, Math.min(0.45, vy * 0.25)));
+
+  // Body
+  ctx.beginPath();
+  ctx.ellipse(0, 0, 14, 9, 0, 0, Math.PI * 2);
+  ctx.fillStyle = "#f97316";
+  ctx.fill();
+
+  // White stripes
+  for (const sx of [-4, 3]) {
+    ctx.beginPath();
+    ctx.ellipse(sx, 0, 2.5, 7, 0, 0, Math.PI * 2);
+    ctx.fillStyle = "rgba(255,255,255,0.85)";
+    ctx.fill();
+  }
+
+  // Tail
+  ctx.beginPath();
+  ctx.moveTo(-12, 0);
+  ctx.lineTo(-20, -8);
+  ctx.lineTo(-20,  8);
+  ctx.closePath();
+  ctx.fillStyle = "#f97316";
+  ctx.fill();
+
+  // Eye
+  ctx.beginPath();
+  ctx.arc(9, -2, 2.5, 0, Math.PI * 2);
+  ctx.fillStyle = "#000";
+  ctx.fill();
+  ctx.beginPath();
+  ctx.arc(9.8, -2.5, 1, 0, Math.PI * 2);
+  ctx.fillStyle = "#fff";
+  ctx.fill();
+
+  ctx.restore();
+}
+
+// ── Coral drawing ─────────────────────────────────────────────────────────────
+function drawCoral(ctx: CanvasRenderingContext2D, x: number, topH: number, botY: number, canvasH: number, live: boolean) {
+  const col = live ? "rgba(20,130,150,0.9)"  : "rgba(20,130,150,0.35)";
+  const cap = live ? "rgba(34,180,190,0.95)" : "rgba(34,180,190,0.35)";
+
+  // Top block
+  ctx.fillStyle = col;
+  ctx.fillRect(x - PIPE_W / 2, 0, PIPE_W, topH);
+  ctx.fillStyle = cap;
+  ctx.fillRect(x - PIPE_W / 2 - 3, topH - 8, PIPE_W + 6, 8);
+
+  // Bottom block
+  ctx.fillStyle = col;
+  ctx.fillRect(x - PIPE_W / 2, botY, PIPE_W, canvasH - botY);
+  ctx.fillStyle = cap;
+  ctx.fillRect(x - PIPE_W / 2 - 3, botY, PIPE_W + 6, 8);
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+export default function CoralSlalom() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const stateRef  = useRef<GameState>("idle");
+  const fishY     = useRef(H / 2);
+  const targetY   = useRef(H / 2);
+  const fishVY    = useRef(0);
+  const pipes     = useRef<Pipe[]>([]);
+  const speed     = useRef(INIT_SPEED);
+  const score     = useRef(0);
+  const frames    = useRef(0);
+  const rafRef    = useRef(0);
+  const W         = useRef(800);
+  const scoreDisplayRef = useRef(0);
+
+  const reset = useCallback(() => {
+    fishY.current    = H / 2;
+    targetY.current  = H / 2;
+    fishVY.current   = 0;
+    pipes.current    = [];
+    speed.current    = INIT_SPEED;
+    score.current    = 0;
+    frames.current   = 0;
+    scoreDisplayRef.current = 0;
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const setSize = () => {
+      W.current = canvas.offsetWidth;
+      canvas.width  = Math.round(W.current * dpr);
+      canvas.height = Math.round(H * dpr);
+    };
+    setSize();
+    const ro = new ResizeObserver(setSize);
+    ro.observe(canvas);
+
+    const onMouseMove = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      const y = e.clientY - rect.top;
+      targetY.current = Math.max(FISH_R + 4, Math.min(H - FISH_R - 4, y));
+      if (stateRef.current === "idle") {
+        reset();
+        fishY.current = targetY.current;
+        stateRef.current = "playing";
+      }
+    };
+
+    const onClick = () => {
+      if (stateRef.current === "dead") {
+        reset();
+        stateRef.current = "playing";
+      }
+    };
+
+    canvas.addEventListener("mousemove", onMouseMove);
+    canvas.addEventListener("click", onClick);
+
+    const ctx = canvas.getContext("2d")!;
+
+    const tick = () => {
+      const cw = W.current;
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.save();
+      ctx.scale(dpr, dpr);
+
+      // Background
+      ctx.fillStyle = "rgb(1, 4, 16)";
+      ctx.fillRect(0, 0, cw, H);
+
+      // Subtle sonar grid
+      ctx.strokeStyle = "rgba(103,232,249,0.04)";
+      ctx.lineWidth = 1;
+      for (let gx = 0; gx < cw; gx += 60) {
+        ctx.beginPath(); ctx.moveTo(gx, 0); ctx.lineTo(gx, H); ctx.stroke();
+      }
+      for (let gy = 0; gy < H; gy += 60) {
+        ctx.beginPath(); ctx.moveTo(0, gy); ctx.lineTo(cw, gy); ctx.stroke();
+      }
+
+      // ── Game logic ──────────────────────────────────────────────────────
+      if (stateRef.current === "playing") {
+        frames.current++;
+        speed.current += SPEED_INC;
+
+        if (frames.current % SCORE_INTERVAL === 0) {
+          score.current++;
+          scoreDisplayRef.current = score.current;
+        }
+
+        // Lerp fish toward mouse
+        const prevY = fishY.current;
+        fishY.current += (targetY.current - fishY.current) * LERP;
+        fishVY.current = fishY.current - prevY;
+
+        // Spawn pipes
+        const last = pipes.current[pipes.current.length - 1];
+        if (!last || last.x < cw - PIPE_INTERVAL) {
+          const min = PIPE_MIN_TOP + GAP / 2;
+          const max = H - PIPE_MIN_TOP - GAP / 2;
+          pipes.current.push({
+            x:    cw + PIPE_W,
+            gapY: min + Math.random() * (max - min),
+          });
+        }
+
+        pipes.current = pipes.current.filter(p => p.x > -PIPE_W - 10);
+        for (const p of pipes.current) {
+          p.x -= speed.current;
+          const nearX = Math.abs(FISH_X - p.x) < FISH_R + PIPE_W / 2;
+          const inGap = fishY.current > p.gapY - GAP / 2 && fishY.current < p.gapY + GAP / 2;
+          if (nearX && !inGap) stateRef.current = "dead";
+        }
+      }
+
+      // ── Draw coral ──────────────────────────────────────────────────────
+      for (const p of pipes.current) {
+        drawCoral(ctx, p.x, p.gapY - GAP / 2, p.gapY + GAP / 2, H, stateRef.current !== "dead");
+      }
+
+      // ── Draw fish ───────────────────────────────────────────────────────
+      drawFish(ctx, FISH_X, fishY.current, fishVY.current, stateRef.current === "dead" ? 0.35 : 1);
+
+      // ── HUD ─────────────────────────────────────────────────────────────
+      ctx.font      = "bold 12px monospace";
+      ctx.textAlign = "right";
+
+      if (stateRef.current === "playing") {
+        ctx.fillStyle = "rgba(103,232,249,0.65)";
+        ctx.fillText(`${scoreDisplayRef.current}`, cw - 12, 18);
+      }
+
+      if (stateRef.current === "idle") {
+        ctx.textAlign = "center";
+        ctx.fillStyle = "rgba(255,255,255,0.7)";
+        ctx.font      = "13px monospace";
+        ctx.fillText("Move your cursor to swim", cw / 2, H / 2 + 5);
+      }
+
+      if (stateRef.current === "dead") {
+        ctx.textAlign = "center";
+        ctx.fillStyle = "rgba(255,255,255,0.8)";
+        ctx.font      = "bold 13px monospace";
+        ctx.fillText(`Score: ${scoreDisplayRef.current}  —  click to retry`, cw / 2, H / 2 + 5);
+      }
+
+      ctx.restore();
+      rafRef.current = requestAnimationFrame(tick);
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      canvas.removeEventListener("mousemove", onMouseMove);
+      canvas.removeEventListener("click", onClick);
+      ro.disconnect();
+    };
+  }, [reset]);
+
+  return (
+    <div className="w-full border-t border-white/8 select-none">
+      <canvas
+        ref={canvasRef}
+        style={{ width: "100%", height: H, display: "block" }}
+      />
+    </div>
+  );
+}

--- a/src/components/FishDodge.tsx
+++ b/src/components/FishDodge.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+const H             = 130;        // canvas height (px)
+const FISH_X        = 70;         // fish fixed x position
+const FISH_R        = 10;         // fish collision radius
+const GRAVITY       = 0.045;
+const FLAP_V        = -1.8;       // upward velocity on click/space
+const INIT_SPEED    = 2.8;
+const SPEED_INC     = 0.00012;    // added to speed each frame
+const PIPE_W        = 18;
+const GAP           = 58;         // gap between top & bottom obstacle
+const PIPE_INTERVAL = 210;        // px between obstacles
+const PIPE_MIN_TOP  = 22;         // min top obstacle height
+const SCORE_INTERVAL = 60;        // frames per score tick
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+type GameState = "idle" | "playing" | "dead";
+
+type Pipe = {
+  x: number;
+  gapY: number; // center of gap
+};
+
+// ── Fish drawing ──────────────────────────────────────────────────────────────
+function drawFish(ctx: CanvasRenderingContext2D, x: number, y: number, vy: number, alpha = 1) {
+  ctx.save();
+  ctx.globalAlpha = alpha;
+  ctx.translate(x, y);
+  // Tilt with velocity
+  ctx.rotate(Math.max(-0.5, Math.min(0.5, vy * 0.07)));
+
+  // Body
+  ctx.beginPath();
+  ctx.ellipse(0, 0, 14, 9, 0, 0, Math.PI * 2);
+  ctx.fillStyle = "#f97316";
+  ctx.fill();
+
+  // White stripes
+  for (const sx of [-4, 3]) {
+    ctx.beginPath();
+    ctx.ellipse(sx, 0, 2.5, 7, 0, 0, Math.PI * 2);
+    ctx.fillStyle = "rgba(255,255,255,0.85)";
+    ctx.fill();
+  }
+
+  // Tail
+  ctx.beginPath();
+  ctx.moveTo(-12, 0);
+  ctx.lineTo(-20, -8);
+  ctx.lineTo(-20, 8);
+  ctx.closePath();
+  ctx.fillStyle = "#f97316";
+  ctx.fill();
+
+  // Eye
+  ctx.beginPath();
+  ctx.arc(9, -2, 2.5, 0, Math.PI * 2);
+  ctx.fillStyle = "#000";
+  ctx.fill();
+  ctx.beginPath();
+  ctx.arc(9.8, -2.5, 1, 0, Math.PI * 2);
+  ctx.fillStyle = "#fff";
+  ctx.fill();
+
+  ctx.restore();
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+export default function FishDodge() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const state     = useRef<GameState>("idle");
+  const fishY     = useRef(H / 2);
+  const fishVY    = useRef(0);
+  const pipes     = useRef<Pipe[]>([]);
+  const speed     = useRef(INIT_SPEED);
+  const score     = useRef(0);
+  const frames    = useRef(0);
+  const rafRef    = useRef(0);
+  const W         = useRef(800);
+
+  const reset = useCallback(() => {
+    fishY.current  = H / 2;
+    fishVY.current = 0;
+    pipes.current  = [];
+    speed.current  = INIT_SPEED;
+    score.current  = 0;
+    frames.current = 0;
+  }, []);
+
+  const flap = useCallback(() => {
+    if (state.current === "idle") {
+      // Start game without applying flap — fish falls from center,
+      // player learns to click to swim up
+      reset();
+      state.current = "playing";
+    } else if (state.current === "playing") {
+      fishVY.current = FLAP_V;
+    } else if (state.current === "dead") {
+      reset();
+      state.current = "playing";
+    }
+  }, [reset]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const setSize = () => {
+      W.current = canvas.offsetWidth;
+      canvas.width  = Math.round(W.current * dpr);
+      canvas.height = Math.round(H * dpr);
+    };
+    setSize();
+    const ro = new ResizeObserver(setSize);
+    ro.observe(canvas);
+
+    const ctx = canvas.getContext("2d")!;
+
+    // Spacebar
+    const onKey = (e: KeyboardEvent) => {
+      if (e.code === "Space") { e.preventDefault(); flap(); }
+    };
+    window.addEventListener("keydown", onKey);
+
+    const tick = () => {
+      const cw = W.current;
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.save();
+      ctx.scale(dpr, dpr);
+
+      // ── Background ───────────────────────────────────────────────────────
+      ctx.fillStyle = "rgb(1, 4, 16)";
+      ctx.fillRect(0, 0, cw, H);
+
+      // Seabed line
+      ctx.strokeStyle = "rgba(103,232,249,0.12)";
+      ctx.lineWidth = 1;
+      ctx.setLineDash([6, 10]);
+      ctx.beginPath();
+      ctx.moveTo(0, H - 1); ctx.lineTo(cw, H - 1);
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      // ── Game logic ────────────────────────────────────────────────────────
+      if (state.current === "playing") {
+        frames.current++;
+        speed.current += SPEED_INC;
+
+        // Score every N frames
+        if (frames.current % SCORE_INTERVAL === 0) score.current++;
+
+        // Physics
+        fishVY.current += GRAVITY;
+        fishY.current  += fishVY.current;
+
+        // Ceiling / floor
+        if (fishY.current - FISH_R <= 0 || fishY.current + FISH_R >= H) {
+          state.current = "dead";
+        }
+
+        // Spawn pipes
+        const lastPipe = pipes.current[pipes.current.length - 1];
+        if (!lastPipe || lastPipe.x < cw - PIPE_INTERVAL) {
+          const minGapCenter = PIPE_MIN_TOP + GAP / 2;
+          const maxGapCenter = H - PIPE_MIN_TOP - GAP / 2;
+          pipes.current.push({
+            x:    cw + PIPE_W,
+            gapY: minGapCenter + Math.random() * (maxGapCenter - minGapCenter),
+          });
+        }
+
+        // Move & cull pipes
+        pipes.current = pipes.current.filter(p => p.x > -PIPE_W);
+        for (const p of pipes.current) {
+          p.x -= speed.current;
+
+          // Collision
+          const nearX = Math.abs(FISH_X - p.x) < FISH_R + PIPE_W / 2;
+          const inGap  = fishY.current > p.gapY - GAP / 2 && fishY.current < p.gapY + GAP / 2;
+          if (nearX && !inGap) state.current = "dead";
+        }
+      }
+
+      // ── Draw pipes ────────────────────────────────────────────────────────
+      for (const p of pipes.current) {
+        const topH    = p.gapY - GAP / 2;
+        const botY    = p.gapY + GAP / 2;
+        const botH    = H - botY;
+        const isLive  = state.current !== "dead";
+        const pipeCol = isLive ? "rgba(14,116,144,0.9)" : "rgba(14,116,144,0.4)";
+        const capCol  = isLive ? "rgba(21,148,180,0.95)" : "rgba(21,148,180,0.4)";
+
+        // Top pipe
+        ctx.fillStyle = pipeCol;
+        ctx.fillRect(p.x - PIPE_W / 2, 0, PIPE_W, topH);
+        ctx.fillStyle = capCol;
+        ctx.fillRect(p.x - PIPE_W / 2 - 3, topH - 8, PIPE_W + 6, 8);
+
+        // Bottom pipe
+        ctx.fillStyle = pipeCol;
+        ctx.fillRect(p.x - PIPE_W / 2, botY, PIPE_W, botH);
+        ctx.fillStyle = capCol;
+        ctx.fillRect(p.x - PIPE_W / 2 - 3, botY, PIPE_W + 6, 8);
+      }
+
+      // ── Draw fish ─────────────────────────────────────────────────────────
+      const fishAlpha = state.current === "dead" ? 0.4 : 1;
+      drawFish(ctx, FISH_X, fishY.current, fishVY.current, fishAlpha);
+
+      // ── HUD ───────────────────────────────────────────────────────────────
+      ctx.font      = "bold 13px monospace";
+      ctx.textAlign = "right";
+
+      if (state.current === "playing" || state.current === "dead") {
+        ctx.fillStyle = "rgba(103,232,249,0.7)";
+        ctx.fillText(`${score.current}`, cw - 12, 20);
+      }
+
+      // Overlay messages
+      if (state.current === "idle" || state.current === "dead") {
+        ctx.textAlign   = "center";
+        ctx.fillStyle   = "rgba(255,255,255,0.85)";
+        ctx.font        = "bold 13px monospace";
+        const msg = state.current === "idle" ? "Click or Space to swim" : `Game over  —  score ${score.current}  —  click to retry`;
+        ctx.fillText(msg, cw / 2, H / 2 + 5);
+      }
+
+      ctx.restore();
+      rafRef.current = requestAnimationFrame(tick);
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      window.removeEventListener("keydown", onKey);
+      ro.disconnect();
+    };
+  }, [flap]);
+
+  return (
+    <div
+      className="w-full border-t border-white/8 cursor-pointer select-none"
+      onClick={flap}
+      title="Click or press Space to play"
+    >
+      <canvas
+        ref={canvasRef}
+        style={{ width: "100%", height: H, display: "block" }}
+      />
+    </div>
+  );
+}

--- a/src/components/FishEat.tsx
+++ b/src/components/FishEat.tsx
@@ -1,0 +1,566 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+const H                = 420;
+const PLAYER_INIT_SIZE = 16;
+const NPC_COUNT        = 22;
+const PLAYER_LERP      = 0.07;
+const NPC_BASE_SPEED   = 0.7;
+const CHASE_RADIUS     = 160;
+const EAT_RATIO        = 1.08;
+const GROW_FACTOR      = 1.045;
+const EDGE_PAD         = 60;
+const SPAWN_INTERVAL_MS = 1200;
+const MAX_NPC_CAP       = 80;
+
+// species: 0=oval  1=torpedo  2=angler  3=puffer  4=tall  5=eel  6=lantern
+type Species = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+const SPECIES_POOL: Species[] = [0,0,0,0, 1,1,1, 2,2, 3,3, 4,4,4, 5,5, 6];
+
+type GameState = "idle" | "playing" | "dead";
+
+type NPC = {
+  id: number;
+  x: number; y: number;
+  vx: number; vy: number;
+  size: number;
+  wobble: number;
+  species: Species;
+};
+
+let nextId = 0;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function spawnNPC(W: number, playerSize: number, fromEdge = true, forceSmaller = false): NPC {
+  const smaller = forceSmaller || Math.random() < 0.68;
+  const size = smaller
+    ? Math.max(6, playerSize * (0.2 + Math.random() * 0.7))
+    : playerSize * (1.1 + Math.random() * 1.2);
+
+  const speed = NPC_BASE_SPEED * (10 / Math.max(size, 10)) * 0.6 + NPC_BASE_SPEED * 0.4;
+  const angle = Math.random() * Math.PI * 2;
+
+  let x: number, y: number;
+  if (fromEdge) {
+    const edge = Math.floor(Math.random() * 4);
+    if (edge === 0)      { x = -size;    y = Math.random() * H; }
+    else if (edge === 1) { x = W + size; y = Math.random() * H; }
+    else if (edge === 2) { x = Math.random() * W; y = -size; }
+    else                 { x = Math.random() * W; y = H + size; }
+  } else {
+    x = Math.random() * W;
+    y = Math.random() * H;
+  }
+
+  const species = SPECIES_POOL[Math.floor(Math.random() * SPECIES_POOL.length)];
+  return { id: nextId++, x, y, vx: Math.cos(angle) * speed, vy: Math.sin(angle) * speed, size, wobble: Math.random() * Math.PI * 2, species };
+}
+
+// ── Species drawing ───────────────────────────────────────────────────────────
+
+// 0 — Generic oval fish (original)
+function drawOval(ctx: CanvasRenderingContext2D, s: number, r: number, g: number, b: number, tailWag: number) {
+  const col  = `rgb(${r},${g},${b})`;
+  const lite = `rgba(${Math.min(r+60,255)},${Math.min(g+60,255)},${Math.min(b+60,255)},0.4)`;
+
+  ctx.beginPath(); ctx.ellipse(0, 0, s, s * 0.6, 0, 0, Math.PI * 2);
+  ctx.fillStyle = col; ctx.fill();
+  ctx.beginPath(); ctx.ellipse(2, 2, s * 0.6, s * 0.35, 0, 0, Math.PI * 2);
+  ctx.fillStyle = lite; ctx.fill();
+
+  ctx.save(); ctx.translate(-s, 0); ctx.rotate(tailWag);
+  ctx.beginPath(); ctx.moveTo(0,0); ctx.lineTo(-s*0.7,-s*0.6); ctx.lineTo(-s*0.7,s*0.6); ctx.closePath();
+  ctx.fillStyle = col; ctx.fill(); ctx.restore();
+
+  const es = Math.max(1.5, s * 0.15);
+  ctx.beginPath(); ctx.arc(s * 0.55, -s * 0.15, es, 0, Math.PI * 2);
+  ctx.fillStyle = "#111"; ctx.fill();
+}
+
+// 1 — Torpedo / tuna — sleek, forked tail, dorsal spike
+function drawTorpedo(ctx: CanvasRenderingContext2D, s: number, r: number, g: number, b: number, tailWag: number) {
+  const col  = `rgb(${r},${g},${b})`;
+  const dark = `rgba(${Math.max(r-40,0)},${Math.max(g-40,0)},${Math.max(b-40,0)},0.9)`;
+
+  // elongated body
+  ctx.beginPath(); ctx.ellipse(0, 0, s * 1.4, s * 0.38, 0, 0, Math.PI * 2);
+  ctx.fillStyle = col; ctx.fill();
+  // belly stripe
+  ctx.beginPath(); ctx.ellipse(s * 0.1, s * 0.1, s * 0.9, s * 0.2, 0, 0, Math.PI * 2);
+  ctx.fillStyle = `rgba(255,255,255,0.18)`; ctx.fill();
+
+  // dorsal fin
+  ctx.beginPath(); ctx.moveTo(s * 0.2, -s * 0.38); ctx.lineTo(s * 0.6, -s * 0.8); ctx.lineTo(-s * 0.2, -s * 0.38); ctx.closePath();
+  ctx.fillStyle = dark; ctx.fill();
+
+  // forked tail
+  ctx.save(); ctx.translate(-s * 1.35, 0); ctx.rotate(tailWag);
+  ctx.beginPath(); ctx.moveTo(0,0); ctx.lineTo(-s*0.7,-s*0.55); ctx.lineTo(-s*0.3,0); ctx.lineTo(-s*0.7,s*0.55); ctx.closePath();
+  ctx.fillStyle = col; ctx.fill(); ctx.restore();
+
+  const es = Math.max(1.2, s * 0.12);
+  ctx.beginPath(); ctx.arc(s * 1.1, -s * 0.08, es, 0, Math.PI * 2);
+  ctx.fillStyle = "#111"; ctx.fill();
+  ctx.beginPath(); ctx.arc(s * 1.14, -s * 0.11, es * 0.45, 0, Math.PI * 2);
+  ctx.fillStyle = "#fff"; ctx.fill();
+}
+
+// 2 — Anglerfish — round body, gaping jaw, glowing lure
+function drawAngler(ctx: CanvasRenderingContext2D, s: number, r: number, g: number, b: number, tailWag: number, t: number) {
+  const col  = `rgb(${Math.max(r-30,0)},${Math.max(g-30,0)},${Math.max(b-30,0)})`;
+
+  // body — wide and rounded
+  ctx.beginPath(); ctx.ellipse(0, -s*0.1, s * 0.95, s * 0.75, 0, 0, Math.PI * 2);
+  ctx.fillStyle = col; ctx.fill();
+
+  // lower jaw juts forward
+  ctx.beginPath();
+  ctx.moveTo(s * 0.5, s * 0.25);
+  ctx.lineTo(s * 0.9, s * 0.55);
+  ctx.lineTo(-s * 0.2, s * 0.55);
+  ctx.lineTo(-s * 0.1, s * 0.2);
+  ctx.closePath();
+  ctx.fillStyle = col; ctx.fill();
+
+  // teeth (top)
+  for (let i = 0; i < 4; i++) {
+    const tx = s * 0.5 - i * s * 0.25;
+    ctx.beginPath(); ctx.moveTo(tx, s * 0.25); ctx.lineTo(tx + s * 0.07, s * 0.5); ctx.lineTo(tx - s * 0.07, s * 0.5); ctx.closePath();
+    ctx.fillStyle = "rgba(255,255,255,0.85)"; ctx.fill();
+  }
+
+  // lure rod from forehead
+  const lureSwing = Math.sin(t * 2.5 + 1) * s * 0.3;
+  ctx.beginPath(); ctx.moveTo(s * 0.3, -s * 0.75); ctx.lineTo(s * 0.55 + lureSwing, -s * 1.35);
+  ctx.strokeStyle = `rgba(${r},${g},${b},0.7)`; ctx.lineWidth = Math.max(1, s * 0.06); ctx.stroke();
+  // lure glow
+  ctx.shadowBlur = 10; ctx.shadowColor = `rgb(${r},${g},${b})`;
+  ctx.beginPath(); ctx.arc(s * 0.55 + lureSwing, -s * 1.38, s * 0.13, 0, Math.PI * 2);
+  ctx.fillStyle = `rgba(${Math.min(r+80,255)},${Math.min(g+80,255)},${Math.min(b+80,255)},0.95)`; ctx.fill();
+  ctx.shadowBlur = 0;
+
+  // tail
+  ctx.save(); ctx.translate(-s * 0.9, -s * 0.1); ctx.rotate(tailWag);
+  ctx.beginPath(); ctx.moveTo(0,0); ctx.lineTo(-s*0.6,-s*0.5); ctx.lineTo(-s*0.6,s*0.5); ctx.closePath();
+  ctx.fillStyle = col; ctx.fill(); ctx.restore();
+
+  // big eye
+  const es = Math.max(2, s * 0.2);
+  ctx.beginPath(); ctx.arc(s * 0.5, -s * 0.25, es, 0, Math.PI * 2);
+  ctx.fillStyle = "#eee"; ctx.fill();
+  ctx.beginPath(); ctx.arc(s * 0.52, -s * 0.27, es * 0.6, 0, Math.PI * 2);
+  ctx.fillStyle = "#000"; ctx.fill();
+  ctx.beginPath(); ctx.arc(s * 0.57, -s * 0.31, es * 0.22, 0, Math.PI * 2);
+  ctx.fillStyle = "#fff"; ctx.fill();
+}
+
+// 3 — Pufferfish — round, spines, spots
+function drawPuffer(ctx: CanvasRenderingContext2D, s: number, r: number, g: number, b: number) {
+  const col  = `rgb(${r},${g},${b})`;
+  const spot = `rgba(${Math.max(r-50,0)},${Math.max(g-50,0)},${Math.max(b-50,0)},0.5)`;
+
+  // round body
+  ctx.beginPath(); ctx.arc(0, 0, s, 0, Math.PI * 2);
+  ctx.fillStyle = col; ctx.fill();
+
+  // spines radiating outward
+  const spineAngles = [-2.0,-1.3,-0.6, 0, 0.6, 1.3, 2.0, 2.7, -2.7, Math.PI];
+  for (const a of spineAngles) {
+    ctx.beginPath();
+    ctx.moveTo(Math.cos(a) * s * 0.9, Math.sin(a) * s * 0.9);
+    ctx.lineTo(Math.cos(a) * (s * 1.3 + s * 0.1), Math.sin(a) * (s * 1.3 + s * 0.1));
+    ctx.strokeStyle = col; ctx.lineWidth = Math.max(1, s * 0.08); ctx.stroke();
+    // spine tip
+    ctx.beginPath(); ctx.arc(Math.cos(a) * s * 1.3, Math.sin(a) * s * 1.3, Math.max(0.8, s * 0.05), 0, Math.PI * 2);
+    ctx.fillStyle = col; ctx.fill();
+  }
+
+  // belly spots
+  for (let i = 0; i < 5; i++) {
+    const sx = (i - 2) * s * 0.32;
+    ctx.beginPath(); ctx.arc(sx, s * 0.3, s * 0.1, 0, Math.PI * 2);
+    ctx.fillStyle = spot; ctx.fill();
+  }
+
+  // tiny tail
+  ctx.beginPath(); ctx.moveTo(-s*0.9,0); ctx.lineTo(-s*1.3,-s*0.35); ctx.lineTo(-s*1.3,s*0.35); ctx.closePath();
+  ctx.fillStyle = col; ctx.fill();
+
+  // tiny mouth
+  ctx.beginPath(); ctx.arc(s * 0.85, s * 0.05, s * 0.1, 0, Math.PI * 2);
+  ctx.fillStyle = `rgba(${Math.max(r-60,0)},${Math.max(g-60,0)},${Math.max(b-60,0)},0.9)`; ctx.fill();
+
+  const es = Math.max(1.5, s * 0.18);
+  ctx.beginPath(); ctx.arc(s * 0.6, -s * 0.35, es, 0, Math.PI * 2);
+  ctx.fillStyle = "#111"; ctx.fill();
+  ctx.beginPath(); ctx.arc(s * 0.65, -s * 0.38, es * 0.4, 0, Math.PI * 2);
+  ctx.fillStyle = "#fff"; ctx.fill();
+}
+
+// 4 — Tall body fish (butterflyfish / surgeonfish) — tall oval, eye stripe
+function drawTall(ctx: CanvasRenderingContext2D, s: number, r: number, g: number, b: number, tailWag: number) {
+  const col  = `rgb(${r},${g},${b})`;
+  const dark = `rgba(${Math.max(r-60,0)},${Math.max(g-60,0)},${Math.max(b-60,0)},0.85)`;
+
+  // tall oval body
+  ctx.beginPath(); ctx.ellipse(0, 0, s * 0.7, s * 1.1, 0, 0, Math.PI * 2);
+  ctx.fillStyle = col; ctx.fill();
+
+  // vertical eye stripe
+  ctx.beginPath(); ctx.ellipse(s * 0.35, 0, s * 0.15, s * 0.9, 0, 0, Math.PI * 2);
+  ctx.fillStyle = dark; ctx.fill();
+
+  // dorsal fin (triangle on top)
+  ctx.beginPath(); ctx.moveTo(-s*0.4, -s*1.1); ctx.lineTo(s*0.3, -s*1.1); ctx.lineTo(s*0.1, -s*1.55); ctx.closePath();
+  ctx.fillStyle = dark; ctx.fill();
+
+  // ventral fin
+  ctx.beginPath(); ctx.moveTo(-s*0.2, s*1.1); ctx.lineTo(s*0.3, s*1.1); ctx.lineTo(s*0.05, s*1.5); ctx.closePath();
+  ctx.fillStyle = dark; ctx.fill();
+
+  // small pointed tail
+  ctx.save(); ctx.translate(-s*0.7, 0); ctx.rotate(tailWag);
+  ctx.beginPath(); ctx.moveTo(0,0); ctx.lineTo(-s*0.55,-s*0.4); ctx.lineTo(-s*0.55,s*0.4); ctx.closePath();
+  ctx.fillStyle = col; ctx.fill(); ctx.restore();
+
+  const es = Math.max(1.5, s * 0.15);
+  ctx.beginPath(); ctx.arc(s * 0.5, -s * 0.25, es, 0, Math.PI * 2);
+  ctx.fillStyle = "#111"; ctx.fill();
+  ctx.beginPath(); ctx.arc(s * 0.55, -s * 0.28, es * 0.4, 0, Math.PI * 2);
+  ctx.fillStyle = "#fff"; ctx.fill();
+}
+
+// 5 — Eel — long sinuous ribbon body
+function drawEel(ctx: CanvasRenderingContext2D, s: number, r: number, g: number, b: number, t: number, wobble: number) {
+  const col = `rgb(${r},${g},${b})`;
+  const len = s * 3.5;
+  const w   = Math.max(2, s * 0.28);
+  const wave1 = Math.sin(t * 4 + wobble) * s * 0.45;
+  const wave2 = Math.sin(t * 4 + wobble + 1.2) * s * 0.3;
+
+  // ribbon body via filled bezier stroke
+  ctx.beginPath();
+  ctx.moveTo(s * 0.6, -w);
+  ctx.bezierCurveTo(0, wave1 - w, -len * 0.55, wave2 - w, -len, -w * 0.4);
+  ctx.lineTo(-len, w * 0.4);
+  ctx.bezierCurveTo(-len * 0.55, wave2 + w, 0, wave1 + w, s * 0.6, w);
+  ctx.closePath();
+  ctx.fillStyle = col; ctx.fill();
+
+  // head
+  ctx.beginPath(); ctx.ellipse(s * 0.55, 0, s * 0.45, s * 0.28, 0, 0, Math.PI * 2);
+  ctx.fillStyle = col; ctx.fill();
+
+  // tail tip
+  ctx.beginPath(); ctx.moveTo(-len, 0); ctx.lineTo(-len - s * 0.5, -s * 0.25); ctx.lineTo(-len - s * 0.5, s * 0.25); ctx.closePath();
+  ctx.fillStyle = col; ctx.fill();
+
+  const es = Math.max(1.2, s * 0.12);
+  ctx.beginPath(); ctx.arc(s * 0.8, -s * 0.08, es, 0, Math.PI * 2);
+  ctx.fillStyle = "#111"; ctx.fill();
+}
+
+// 6 — Lanternfish — small round, huge eyes, glowing belly dots
+function drawLantern(ctx: CanvasRenderingContext2D, s: number, r: number, g: number, b: number, tailWag: number, t: number) {
+  const col = `rgb(${Math.max(r-20,0)},${Math.max(g-20,0)},${Math.max(b-20,0)})`;
+
+  // body
+  ctx.beginPath(); ctx.ellipse(0, 0, s, s * 0.65, 0, 0, Math.PI * 2);
+  ctx.fillStyle = col; ctx.fill();
+
+  // tail
+  ctx.save(); ctx.translate(-s, 0); ctx.rotate(tailWag);
+  ctx.beginPath(); ctx.moveTo(0,0); ctx.lineTo(-s*0.65,-s*0.5); ctx.lineTo(-s*0.65,s*0.5); ctx.closePath();
+  ctx.fillStyle = col; ctx.fill(); ctx.restore();
+
+  // glowing belly photophores
+  const glowPulse = 0.7 + Math.sin(t * 3 + 1) * 0.3;
+  ctx.shadowBlur = 8 * glowPulse;
+  ctx.shadowColor = `rgb(${Math.min(r+100,255)},${Math.min(g+100,255)},${Math.min(b+100,255)})`;
+  for (let i = 0; i < 4; i++) {
+    const dx = (i - 1.5) * s * 0.42;
+    ctx.beginPath(); ctx.arc(dx, s * 0.35, Math.max(1, s * 0.09), 0, Math.PI * 2);
+    ctx.fillStyle = `rgba(${Math.min(r+120,255)},${Math.min(g+120,255)},${Math.min(b+120,255)},${glowPulse})`;
+    ctx.fill();
+  }
+  ctx.shadowBlur = 0;
+
+  // oversized eyes (deep sea adaptation)
+  const es = Math.max(2, s * 0.28);
+  ctx.beginPath(); ctx.arc(s * 0.55, -s * 0.1, es, 0, Math.PI * 2);
+  ctx.fillStyle = "#dde"; ctx.fill();
+  ctx.beginPath(); ctx.arc(s * 0.57, -s * 0.12, es * 0.65, 0, Math.PI * 2);
+  ctx.fillStyle = "#000"; ctx.fill();
+  ctx.beginPath(); ctx.arc(s * 0.62, -s * 0.17, es * 0.25, 0, Math.PI * 2);
+  ctx.fillStyle = "#fff"; ctx.fill();
+}
+
+// ── NPC dispatch ──────────────────────────────────────────────────────────────
+function drawNPC(ctx: CanvasRenderingContext2D, npc: NPC, playerSize: number, t: number) {
+  const ratio = npc.size / playerSize;
+  let r: number, g: number, b: number;
+  if (ratio < 0.85)             { r = 60;  g = 200; b = 160; }
+  else if (ratio < 1 / EAT_RATIO) { r = 230; g = 200; b = 60;  }
+  else                           { r = 220; g = 60;  b = 60;  }
+
+  const tailWag = Math.sin(t * 7 + npc.wobble) * 0.3;
+
+  ctx.save();
+  ctx.translate(npc.x, npc.y);
+  if (npc.vx < 0) ctx.scale(-1, 1);
+
+  switch (npc.species) {
+    case 0: drawOval(ctx, npc.size, r, g, b, tailWag); break;
+    case 1: drawTorpedo(ctx, npc.size, r, g, b, tailWag); break;
+    case 2: drawAngler(ctx, npc.size, r, g, b, tailWag, t); break;
+    case 3: drawPuffer(ctx, npc.size, r, g, b); break;
+    case 4: drawTall(ctx, npc.size, r, g, b, tailWag); break;
+    case 5: drawEel(ctx, npc.size, r, g, b, t, npc.wobble); break;
+    case 6: drawLantern(ctx, npc.size, r, g, b, tailWag, t); break;
+  }
+
+  ctx.restore();
+}
+
+// ── Player fish (clownfish) ───────────────────────────────────────────────────
+function drawPlayerFish(ctx: CanvasRenderingContext2D, x: number, y: number, size: number, vx: number, vy: number, t: number) {
+  const scale = size / PLAYER_INIT_SIZE;
+  ctx.save();
+  ctx.translate(x, y);
+  if (vx < -0.1) ctx.scale(-1, 1);
+  ctx.rotate(Math.max(-0.4, Math.min(0.4, vy * 0.2)));
+  ctx.scale(scale, scale);
+
+  // Body
+  ctx.beginPath(); ctx.ellipse(0, 0, 14, 9, 0, 0, Math.PI * 2);
+  ctx.fillStyle = "#f97316"; ctx.fill();
+
+  // White stripes
+  for (const sx of [-4, 3]) {
+    ctx.beginPath(); ctx.ellipse(sx, 0, 2.5, 7, 0, 0, Math.PI * 2);
+    ctx.fillStyle = "rgba(255,255,255,0.85)"; ctx.fill();
+  }
+
+  // Animated tail
+  const tailWag = Math.sin(t * 8) * 0.3;
+  ctx.save(); ctx.translate(-12, 0); ctx.rotate(tailWag);
+  ctx.beginPath(); ctx.moveTo(0,0); ctx.lineTo(-9,-9); ctx.lineTo(-9,9); ctx.closePath();
+  ctx.fillStyle = "#f97316"; ctx.fill(); ctx.restore();
+
+  // Eye
+  ctx.beginPath(); ctx.arc(9, -2, 2.5, 0, Math.PI * 2); ctx.fillStyle = "#000"; ctx.fill();
+  ctx.beginPath(); ctx.arc(9.8, -2.5, 1, 0, Math.PI * 2); ctx.fillStyle = "#fff"; ctx.fill();
+
+  ctx.restore();
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+export default function FishEat() {
+  const canvasRef   = useRef<HTMLCanvasElement>(null);
+  const stateRef    = useRef<GameState>("idle");
+  const playerX     = useRef(0);
+  const playerY     = useRef(H / 2);
+  const playerVX    = useRef(0);
+  const playerVY    = useRef(0);
+  const targetX     = useRef(0);
+  const targetY     = useRef(H / 2);
+  const playerSize  = useRef(PLAYER_INIT_SIZE);
+  const npcs        = useRef<NPC[]>([]);
+  const score       = useRef(0);
+  const rafRef      = useRef(0);
+  const W           = useRef(600);
+  const lastSpawn   = useRef(0);
+
+  const reset = useCallback(() => {
+    const w = W.current;
+    playerX.current    = w * 0.2;
+    playerY.current    = H / 2;
+    targetX.current    = w * 0.2;
+    targetY.current    = H / 2;
+    playerVX.current   = 0;
+    playerVY.current   = 0;
+    playerSize.current = PLAYER_INIT_SIZE;
+    score.current      = 0;
+    lastSpawn.current  = performance.now();
+    npcs.current       = Array.from({ length: NPC_COUNT }, () => spawnNPC(w, PLAYER_INIT_SIZE, false));
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const setSize = () => {
+      W.current = canvas.offsetWidth;
+      canvas.width  = Math.round(W.current * dpr);
+      canvas.height = Math.round(H * dpr);
+    };
+    setSize();
+    const ro = new ResizeObserver(setSize);
+    ro.observe(canvas);
+
+    const onMouseMove = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      targetX.current = e.clientX - rect.left;
+      targetY.current = e.clientY - rect.top;
+    };
+
+    const onClick = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      targetX.current = e.clientX - rect.left;
+      targetY.current = e.clientY - rect.top;
+      if (stateRef.current === "idle" || stateRef.current === "dead") {
+        reset();
+        playerX.current = targetX.current;
+        playerY.current = targetY.current;
+        stateRef.current = "playing";
+      }
+    };
+
+    canvas.addEventListener("mousemove", onMouseMove);
+    canvas.addEventListener("click", onClick);
+
+    const ctx = canvas.getContext("2d")!;
+
+    const tick = () => {
+      const cw  = W.current;
+      const t   = performance.now() * 0.001;
+      const now = performance.now();
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.save();
+      ctx.scale(dpr, dpr);
+
+      // Background
+      const bg = ctx.createLinearGradient(0, 0, 0, H);
+      bg.addColorStop(0, "rgb(2, 10, 30)");
+      bg.addColorStop(1, "rgb(1, 4, 16)");
+      ctx.fillStyle = bg; ctx.fillRect(0, 0, cw, H);
+
+      // Bubbles
+      ctx.fillStyle = "rgba(103,232,249,0.06)";
+      for (let i = 0; i < 8; i++) {
+        const bx = ((i * 137 + t * 20) % cw);
+        const by = H - ((t * (10 + i * 3)) % (H + 20));
+        ctx.beginPath(); ctx.arc(bx, by, 2 + (i % 3), 0, Math.PI * 2); ctx.fill();
+      }
+
+      if (stateRef.current === "playing") {
+        // Player movement (lerp)
+        const prevX      = playerX.current;
+        const prevY      = playerY.current;
+        playerX.current += (targetX.current - playerX.current) * PLAYER_LERP;
+        playerY.current += (targetY.current - playerY.current) * PLAYER_LERP;
+        playerVX.current = playerX.current - prevX;
+        playerVY.current = playerY.current - prevY;
+
+        // Clamp
+        const ps = playerSize.current;
+        playerX.current = Math.max(ps, Math.min(cw - ps, playerX.current));
+        playerY.current = Math.max(ps, Math.min(H  - ps, playerY.current));
+
+        // Continuous spawning — burst more when pool is sparse
+        if (now - lastSpawn.current > SPAWN_INTERVAL_MS && npcs.current.length < MAX_NPC_CAP) {
+          lastSpawn.current = now;
+          const smallCount = npcs.current.filter(n => n.size < ps).length;
+          const forceSmaller = smallCount < npcs.current.length * 0.5;
+          const burst = npcs.current.length < NPC_COUNT ? 3 : 1;
+          for (let i = 0; i < burst && npcs.current.length < MAX_NPC_CAP; i++) {
+            npcs.current.push(spawnNPC(cw, ps, true, forceSmaller));
+          }
+        }
+
+        // NPC AI
+        for (const npc of npcs.current) {
+          const ndx   = playerX.current - npc.x;
+          const ndy   = playerY.current - npc.y;
+          const ndist = Math.hypot(ndx, ndy);
+          if (npc.size > ps * EAT_RATIO && ndist < CHASE_RADIUS) {
+            const force = (1 - ndist / CHASE_RADIUS) * 0.09;
+            npc.vx += (ndx / ndist) * force;
+            npc.vy += (ndy / ndist) * force;
+          }
+          const spd    = Math.hypot(npc.vx, npc.vy);
+          const maxSpd = NPC_BASE_SPEED * (12 / Math.max(npc.size, 8));
+          if (spd > maxSpd) { npc.vx = (npc.vx / spd) * maxSpd; npc.vy = (npc.vy / spd) * maxSpd; }
+          npc.x += npc.vx; npc.y += npc.vy;
+          if (npc.x < -EDGE_PAD) npc.x = cw + EDGE_PAD;
+          if (npc.x > cw + EDGE_PAD) npc.x = -EDGE_PAD;
+          if (npc.y < -EDGE_PAD) npc.y = H + EDGE_PAD;
+          if (npc.y > H + EDGE_PAD) npc.y = -EDGE_PAD;
+        }
+
+        // Collision
+        npcs.current = npcs.current.filter(npc => {
+          const cdist  = Math.hypot(playerX.current - npc.x, playerY.current - npc.y);
+          const overlap = cdist < ps * 0.8 + npc.size * 0.8;
+          if (!overlap) return true;
+          if (ps > npc.size * EAT_RATIO) {
+            score.current++;
+            playerSize.current *= GROW_FACTOR;
+            const smallCount = npcs.current.filter(n => n.size < ps).length;
+            npcs.current.push(spawnNPC(cw, playerSize.current, true, smallCount < NPC_COUNT * 0.5));
+            return false;
+          } else if (npc.size > ps * EAT_RATIO) {
+            stateRef.current = "dead";
+          }
+          return true;
+        });
+      }
+
+      // Draw NPCs
+      for (const npc of npcs.current) drawNPC(ctx, npc, playerSize.current, t);
+
+      // Draw player
+      if (stateRef.current !== "idle") {
+        drawPlayerFish(ctx, playerX.current, playerY.current, playerSize.current, playerVX.current, playerVY.current, t);
+      }
+
+      // HUD
+      ctx.font = "bold 13px monospace"; ctx.textAlign = "left";
+      if (stateRef.current === "playing") {
+        ctx.fillStyle = "rgba(103,232,249,0.7)";
+        ctx.fillText(`${score.current} eaten`, 14, 22);
+      }
+      if (stateRef.current === "idle") {
+        ctx.textAlign = "center";
+        ctx.fillStyle = "rgba(255,255,255,0.75)"; ctx.font = "14px monospace";
+        ctx.fillText("Click to start swimming", cw / 2, H / 2 - 10);
+        ctx.fillStyle = "rgba(255,255,255,0.4)"; ctx.font = "12px monospace";
+        ctx.fillText("Eat smaller fish  •  avoid bigger ones", cw / 2, H / 2 + 14);
+      }
+      if (stateRef.current === "dead") {
+        ctx.textAlign = "center";
+        ctx.fillStyle = "rgba(0,0,0,0.5)";
+        ctx.fillRect(cw / 2 - 160, H / 2 - 36, 320, 72);
+        ctx.fillStyle = "rgba(255,255,255,0.9)"; ctx.font = "bold 15px monospace";
+        ctx.fillText(`You got eaten!  Score: ${score.current}`, cw / 2, H / 2 - 8);
+        ctx.fillStyle = "rgba(255,255,255,0.5)"; ctx.font = "12px monospace";
+        ctx.fillText("Click to try again", cw / 2, H / 2 + 16);
+      }
+
+      ctx.restore();
+      rafRef.current = requestAnimationFrame(tick);
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      canvas.removeEventListener("mousemove", onMouseMove);
+      canvas.removeEventListener("click", onClick);
+      ro.disconnect();
+    };
+  }, [reset]);
+
+  return (
+    <div className="w-full select-none">
+      <canvas
+        ref={canvasRef}
+        style={{ width: "100%", height: H, display: "block", touchAction: "none" }}
+        className="rounded-2xl border border-white/10"
+      />
+    </div>
+  );
+}

--- a/src/components/SeaFloorHop.tsx
+++ b/src/components/SeaFloorHop.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+const H             = 200;
+const FISH_X        = 72;
+const FISH_R        = 11;
+const FLOOR_Y       = H - 36;
+const GRAVITY       = 0.13;
+const JUMP_V        = -4.2;
+const INIT_SPEED    = 3.2;
+const SPEED_INC     = 0.00009;
+const SCORE_INTERVAL = 55; // frames per point
+
+// type 0=crab  1=urchin  2=starfish  3=hermit
+type ObsType = 0 | 1 | 2 | 3;
+const OBS_HW = [22, 13, 20, 17];   // half-width for collision
+const OBS_CH = [22, 38, 13, 28];   // collision height above floor
+
+type GameState = "idle" | "playing" | "dead";
+type Obstacle  = { x: number; type: ObsType };
+
+// ── Fish ──────────────────────────────────────────────────────────────────────
+function drawFish(ctx: CanvasRenderingContext2D, x: number, y: number, vy: number, t: number, alpha = 1) {
+  ctx.save();
+  ctx.globalAlpha = alpha;
+  ctx.translate(x, y);
+  ctx.rotate(Math.max(-0.45, Math.min(0.45, vy * 0.09)));
+
+  const tailWag = Math.sin(t * 9) * 0.28;
+
+  // Body
+  ctx.beginPath(); ctx.ellipse(0, 0, 14, 9, 0, 0, Math.PI * 2);
+  ctx.fillStyle = "#f97316"; ctx.fill();
+  // Stripes
+  for (const sx of [-4, 3]) {
+    ctx.beginPath(); ctx.ellipse(sx, 0, 2.5, 7, 0, 0, Math.PI * 2);
+    ctx.fillStyle = "rgba(255,255,255,0.85)"; ctx.fill();
+  }
+  // Tail
+  ctx.save(); ctx.translate(-12, 0); ctx.rotate(tailWag);
+  ctx.beginPath(); ctx.moveTo(0,0); ctx.lineTo(-9,-9); ctx.lineTo(-9,9); ctx.closePath();
+  ctx.fillStyle = "#f97316"; ctx.fill(); ctx.restore();
+  // Eye
+  ctx.beginPath(); ctx.arc(9,-2,2.5,0,Math.PI*2); ctx.fillStyle="#000"; ctx.fill();
+  ctx.beginPath(); ctx.arc(9.8,-2.5,1,0,Math.PI*2); ctx.fillStyle="#fff"; ctx.fill();
+
+  ctx.restore();
+}
+
+// ── Obstacles ─────────────────────────────────────────────────────────────────
+
+function drawCrab(ctx: CanvasRenderingContext2D, cx: number) {
+  const y = FLOOR_Y - 4;
+  const col = "#e05533";
+  const dark = "#b03a20";
+
+  // legs
+  ctx.strokeStyle = col; ctx.lineWidth = 2;
+  for (const [ox, oy] of [[-14,6],[-8,9],[8,9],[14,6]]) {
+    ctx.beginPath(); ctx.moveTo(cx+ox*0.5, y-4); ctx.lineTo(cx+ox, y+oy); ctx.stroke();
+  }
+
+  // body
+  ctx.beginPath(); ctx.ellipse(cx, y-10, 20, 12, 0, 0, Math.PI*2);
+  ctx.fillStyle = col; ctx.fill();
+  // belly
+  ctx.beginPath(); ctx.ellipse(cx, y-8, 13, 7, 0, 0, Math.PI*2);
+  ctx.fillStyle = `rgba(240,120,80,0.5)`; ctx.fill();
+
+  // left claw
+  ctx.fillStyle = dark;
+  ctx.beginPath(); ctx.moveTo(cx-20,y-10); ctx.lineTo(cx-32,y-18); ctx.lineTo(cx-28,y-4); ctx.closePath(); ctx.fill();
+  ctx.beginPath(); ctx.moveTo(cx-20,y-10); ctx.lineTo(cx-30,y-6); ctx.lineTo(cx-26,y+2); ctx.closePath(); ctx.fill();
+  // right claw
+  ctx.beginPath(); ctx.moveTo(cx+20,y-10); ctx.lineTo(cx+32,y-18); ctx.lineTo(cx+28,y-4); ctx.closePath(); ctx.fill();
+  ctx.beginPath(); ctx.moveTo(cx+20,y-10); ctx.lineTo(cx+30,y-6); ctx.lineTo(cx+26,y+2); ctx.closePath(); ctx.fill();
+
+  // eyes on stalks
+  for (const ex of [-8, 8]) {
+    ctx.beginPath(); ctx.moveTo(cx+ex, y-22); ctx.lineTo(cx+ex, y-28);
+    ctx.strokeStyle = col; ctx.lineWidth = 2; ctx.stroke();
+    ctx.beginPath(); ctx.arc(cx+ex, y-29, 4, 0, Math.PI*2);
+    ctx.fillStyle = col; ctx.fill();
+    ctx.beginPath(); ctx.arc(cx+ex+1, y-30, 2, 0, Math.PI*2);
+    ctx.fillStyle = "#111"; ctx.fill();
+  }
+}
+
+function drawUrchin(ctx: CanvasRenderingContext2D, cx: number) {
+  const cy = FLOOR_Y - 18;
+  const r  = 14;
+  const col = "#7c3f8a";
+
+  // spines
+  ctx.strokeStyle = col; ctx.lineWidth = 2;
+  for (let i = 0; i < 12; i++) {
+    const a = (i / 12) * Math.PI * 2 - Math.PI / 2;
+    // only draw spines above floor
+    if (Math.sin(a) > 0.3) continue;
+    ctx.beginPath();
+    ctx.moveTo(cx + Math.cos(a)*r, cy + Math.sin(a)*r);
+    ctx.lineTo(cx + Math.cos(a)*(r+10), cy + Math.sin(a)*(r+10));
+    ctx.stroke();
+    ctx.beginPath(); ctx.arc(cx + Math.cos(a)*(r+11), cy + Math.sin(a)*(r+11), 2, 0, Math.PI*2);
+    ctx.fillStyle = col; ctx.fill();
+  }
+
+  // body
+  ctx.beginPath(); ctx.arc(cx, cy, r, 0, Math.PI*2);
+  ctx.fillStyle = col; ctx.fill();
+  ctx.beginPath(); ctx.arc(cx-3, cy-4, r*0.45, 0, Math.PI*2);
+  ctx.fillStyle = "rgba(180,100,200,0.35)"; ctx.fill();
+
+  // mouth dot
+  ctx.beginPath(); ctx.arc(cx, cy+3, 3, 0, Math.PI*2);
+  ctx.fillStyle = "#3a1a44"; ctx.fill();
+}
+
+function drawStarfish(ctx: CanvasRenderingContext2D, cx: number) {
+  const cy = FLOOR_Y - 8;
+  const col = "#e8884a";
+
+  ctx.save(); ctx.translate(cx, cy);
+  ctx.beginPath();
+  for (let i = 0; i < 10; i++) {
+    const a = (i / 10) * Math.PI * 2 - Math.PI / 2;
+    const r = i % 2 === 0 ? 20 : 9;
+    if (i === 0) ctx.moveTo(Math.cos(a)*r, Math.sin(a)*r);
+    else ctx.lineTo(Math.cos(a)*r, Math.sin(a)*r);
+  }
+  ctx.closePath();
+  ctx.fillStyle = col; ctx.fill();
+  // texture dots
+  ctx.fillStyle = "rgba(255,180,100,0.5)";
+  for (const [dx,dy] of [[0,-5],[6,3],[-6,3],[4,-8],[-4,-8]]) {
+    ctx.beginPath(); ctx.arc(dx, dy, 2.5, 0, Math.PI*2); ctx.fill();
+  }
+  ctx.restore();
+}
+
+function drawHermit(ctx: CanvasRenderingContext2D, cx: number) {
+  const y = FLOOR_Y;
+  const col = "#5a9a6e";
+  const shellCol = "#c47a3a";
+
+  // legs
+  ctx.strokeStyle = col; ctx.lineWidth = 2;
+  for (const [ox, oy] of [[-10,5],[-5,8],[5,8],[10,5]]) {
+    ctx.beginPath(); ctx.moveTo(cx+ox*0.4, y-8); ctx.lineTo(cx+ox, y+oy); ctx.stroke();
+  }
+
+  // shell (dome)
+  ctx.beginPath(); ctx.ellipse(cx+4, y-18, 18, 22, -0.3, Math.PI, 0);
+  ctx.fillStyle = shellCol; ctx.fill();
+  // shell spiral lines
+  ctx.strokeStyle = "rgba(160,90,20,0.6)"; ctx.lineWidth = 1.5;
+  ctx.beginPath(); ctx.arc(cx+8, y-20, 8, 0.2, Math.PI*1.5); ctx.stroke();
+  ctx.beginPath(); ctx.arc(cx+8, y-20, 4, 0.5, Math.PI*1.3); ctx.stroke();
+
+  // head/claw poking out
+  ctx.beginPath(); ctx.ellipse(cx-10, y-10, 8, 6, 0, 0, Math.PI*2);
+  ctx.fillStyle = col; ctx.fill();
+  // claw
+  ctx.beginPath(); ctx.moveTo(cx-16,y-12); ctx.lineTo(cx-22,y-18); ctx.lineTo(cx-18,y-8); ctx.closePath();
+  ctx.fillStyle = "#3a7050"; ctx.fill();
+  // eye
+  ctx.beginPath(); ctx.arc(cx-13, y-13, 2.5, 0, Math.PI*2);
+  ctx.fillStyle = "#111"; ctx.fill();
+  ctx.beginPath(); ctx.arc(cx-12, y-14, 1, 0, Math.PI*2);
+  ctx.fillStyle = "#fff"; ctx.fill();
+}
+
+function drawObstacle(ctx: CanvasRenderingContext2D, obs: Obstacle) {
+  switch (obs.type) {
+    case 0: drawCrab(ctx, obs.x); break;
+    case 1: drawUrchin(ctx, obs.x); break;
+    case 2: drawStarfish(ctx, obs.x); break;
+    case 3: drawHermit(ctx, obs.x); break;
+  }
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+export default function SeaFloorHop() {
+  const canvasRef  = useRef<HTMLCanvasElement>(null);
+  const stateRef   = useRef<GameState>("idle");
+  const fishY      = useRef(FLOOR_Y - FISH_R);
+  const fishVY     = useRef(0);
+  const obstacles  = useRef<Obstacle[]>([]);
+  const speed      = useRef(INIT_SPEED);
+  const score      = useRef(0);
+  const frames     = useRef(0);
+  const rafRef     = useRef(0);
+  const W          = useRef(400);
+  const nextObsAt  = useRef(220);
+
+  const reset = useCallback(() => {
+    fishY.current     = FLOOR_Y - FISH_R;
+    fishVY.current    = 0;
+    obstacles.current = [];
+    speed.current     = INIT_SPEED;
+    score.current     = 0;
+    frames.current    = 0;
+    nextObsAt.current = 220;
+  }, []);
+
+  const jump = useCallback(() => {
+    if (stateRef.current === "idle") {
+      reset();
+      stateRef.current = "playing";
+      fishVY.current = JUMP_V;
+    } else if (stateRef.current === "playing") {
+      fishVY.current = JUMP_V;
+    } else if (stateRef.current === "dead") {
+      reset();
+      stateRef.current = "playing";
+      fishVY.current = JUMP_V;
+    }
+  }, [reset]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const setSize = () => {
+      W.current = canvas.offsetWidth;
+      canvas.width  = Math.round(W.current * dpr);
+      canvas.height = Math.round(H * dpr);
+    };
+    setSize();
+    const ro = new ResizeObserver(setSize);
+    ro.observe(canvas);
+
+    const onTouchStart = (e: TouchEvent) => { e.preventDefault(); jump(); };
+    canvas.addEventListener("touchstart", onTouchStart, { passive: false });
+
+    const ctx = canvas.getContext("2d")!;
+
+    const tick = () => {
+      const cw = W.current;
+      const t  = performance.now() * 0.001;
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.save();
+      ctx.scale(dpr, dpr);
+
+      // Background
+      const bg = ctx.createLinearGradient(0, 0, 0, H);
+      bg.addColorStop(0, "rgb(2, 12, 35)");
+      bg.addColorStop(1, "rgb(4, 18, 12)");
+      ctx.fillStyle = bg; ctx.fillRect(0, 0, cw, H);
+
+      // Distant bubbles
+      ctx.fillStyle = "rgba(103,232,249,0.05)";
+      for (let i = 0; i < 6; i++) {
+        ctx.beginPath();
+        ctx.arc((i*173 + t*15) % cw, H - ((t*(8+i*2)) % (H+10)), 1.5 + (i%3)*0.5, 0, Math.PI*2);
+        ctx.fill();
+      }
+
+      // Sandy floor
+      ctx.fillStyle = "rgba(180,150,90,0.18)";
+      ctx.fillRect(0, FLOOR_Y + 4, cw, H - FLOOR_Y - 4);
+      // Floor line
+      ctx.strokeStyle = "rgba(180,150,90,0.35)";
+      ctx.lineWidth = 1.5;
+      ctx.beginPath(); ctx.moveTo(0, FLOOR_Y+4); ctx.lineTo(cw, FLOOR_Y+4); ctx.stroke();
+      // Pebbles
+      ctx.fillStyle = "rgba(120,100,60,0.25)";
+      for (let i = 0; i < 12; i++) {
+        ctx.beginPath();
+        ctx.ellipse((i*97+31) % cw, FLOOR_Y+10+(i%3)*4, 4+i%5, 2, 0, 0, Math.PI*2);
+        ctx.fill();
+      }
+
+      if (stateRef.current === "playing") {
+        frames.current++;
+        speed.current += SPEED_INC;
+        if (frames.current % SCORE_INTERVAL === 0) score.current++;
+
+        // Physics
+        fishVY.current += GRAVITY;
+        fishY.current  += fishVY.current;
+
+        // Floor — bounce gently, no death
+        if (fishY.current >= FLOOR_Y - FISH_R) {
+          fishY.current  = FLOOR_Y - FISH_R;
+          fishVY.current = 0;
+        }
+        // Ceiling — cap, no death
+        if (fishY.current <= FISH_R) {
+          fishY.current  = FISH_R;
+          fishVY.current = Math.max(0, fishVY.current);
+        }
+
+        // Spawn obstacles
+        if (obstacles.current.length === 0 || cw - obstacles.current[obstacles.current.length-1].x > nextObsAt.current) {
+          const type = Math.floor(Math.random() * 4) as ObsType;
+          obstacles.current.push({ x: cw + 30, type });
+          nextObsAt.current = 200 + Math.random() * 200;
+        }
+
+        // Move & cull
+        obstacles.current = obstacles.current.filter(o => o.x > -60);
+        for (const obs of obstacles.current) {
+          obs.x -= speed.current;
+
+          // Collision
+          const hw   = OBS_HW[obs.type];
+          const ch   = OBS_CH[obs.type];
+          const nearX = Math.abs(FISH_X - obs.x) < FISH_R + hw - 4;
+          const nearY = fishY.current + FISH_R > FLOOR_Y - ch;
+          if (nearX && nearY) stateRef.current = "dead";
+        }
+      }
+
+      // Draw obstacles
+      for (const obs of obstacles.current) drawObstacle(ctx, obs);
+
+      // Draw fish
+      drawFish(ctx, FISH_X, fishY.current, fishVY.current, t, stateRef.current === "dead" ? 0.35 : 1);
+
+      // HUD
+      ctx.font = "bold 12px monospace"; ctx.textAlign = "right";
+      if (stateRef.current === "playing") {
+        ctx.fillStyle = "rgba(103,232,249,0.65)";
+        ctx.fillText(`${score.current}`, cw - 12, 18);
+      }
+
+      if (stateRef.current === "idle") {
+        ctx.textAlign = "center";
+        ctx.fillStyle = "rgba(255,255,255,0.75)"; ctx.font = "14px monospace";
+        ctx.fillText("Tap to jump", cw/2, H/2 - 8);
+        ctx.fillStyle = "rgba(255,255,255,0.38)"; ctx.font = "11px monospace";
+        ctx.fillText("hop over the sea creatures", cw/2, H/2 + 14);
+      }
+
+      if (stateRef.current === "dead") {
+        ctx.textAlign = "center";
+        ctx.fillStyle = "rgba(0,0,0,0.5)";
+        ctx.fillRect(cw/2 - 130, H/2 - 28, 260, 58);
+        ctx.fillStyle = "rgba(255,255,255,0.9)"; ctx.font = "bold 13px monospace";
+        ctx.fillText(`Squished!  Score: ${score.current}`, cw/2, H/2 - 4);
+        ctx.fillStyle = "rgba(255,255,255,0.5)"; ctx.font = "11px monospace";
+        ctx.fillText("Tap to try again", cw/2, H/2 + 18);
+      }
+
+      ctx.restore();
+      rafRef.current = requestAnimationFrame(tick);
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      canvas.removeEventListener("touchstart", onTouchStart);
+      ro.disconnect();
+    };
+  }, [jump]);
+
+  return (
+    <div
+      className="w-full select-none"
+      onClick={jump}
+    >
+      <canvas
+        ref={canvasRef}
+        style={{ width: "100%", height: H, display: "block", touchAction: "none" }}
+        className="rounded-2xl border border-white/10"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **FishEat** (desktop only): eat-or-be-eaten canvas game with 7 NPC species — oval, torpedo/tuna, anglerfish with animated lure, pufferfish with spines, butterflyfish, eel, and lanternfish with glowing photophores. Continuous fish spawning, danger color coding (green/yellow/red), no size cap so you can grow comically large.
- **SeaFloorHop** (mobile only): tap-to-jump endless runner with floaty underwater physics. Hop over crabs, sea urchins, starfish, and hermit crabs along a sandy sea floor. Floor and ceiling are safe — only touching creatures kills you.
- Both games live at the bottom of the page, below the contact CTA.

## Test plan
- [ ] Desktop: FishEat renders and is playable with mouse
- [ ] Mobile: SeaFloorHop renders and responds to taps
- [ ] Fish species variety visible in FishEat (anglerfish lure, eel wave, lanternfish glow)
- [ ] Fish pool replenishes as you eat
- [ ] SeaFloorHop physics feel slow and floaty (underwater)
- [ ] Game section appears after "Let's work together" CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)