### PR TITLE
Scroll-driven Projects showcase with HUD terminal screen

### DIFF
--- a/public/bloomberg/index.css
+++ b/public/bloomberg/index.css
@@ -1,0 +1,1 @@
+/* Bloomberg banner shared styles — intentionally empty; banners use inline <style> blocks */

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+/**
+ * Shared modal shell.
+ * Always restores cursor visibility — body may have cursor:none from the fish cursor,
+ * so every modal must override it or users lose their pointer inside the overlay.
+ */
+export default function Modal({ isOpen, onClose, children }: ModalProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isOpen, onClose]);
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center p-6"
+          style={{ cursor: "default" }}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          onClick={onClose}
+        >
+          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+          <motion.div
+            className="relative"
+            initial={{ scale: 0.95, y: 12 }}
+            animate={{ scale: 1, y: 0 }}
+            exit={{ scale: 0.95, y: 12 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {children}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -62,7 +62,7 @@ function HudScreen({ project, imageIdx, onPrev, onNext, onImageChange }: HudScre
       {/* Screen frame — persistent, never animates */}
       <div
         className="relative overflow-hidden"
-        className="md:[transform:perspective(1100px)_rotateY(-6deg)_rotateX(2deg)] md:[transform-origin:center_center]"
+        className="md:[transform:perspective(1200px)_rotateX(3deg)] md:[transform-origin:center_top]"
         style={{
           borderRadius: "4px 20px 8px 6px",
           border: "1px solid color-mix(in srgb, var(--zone-accent) 38%, transparent)",

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -43,12 +43,14 @@ function ScreenBrackets() {
 }
 
 // ── HUD terminal screen ────────────────────────────────────────────────────────
+// The outer frame is always present; only the media content inside transitions
+// (channel-change effect — the TV stays on, the channel switches).
 function HudScreen({ project }: { project: Project }) {
   const hasImage = project.images.length > 0;
 
   return (
     <div className="relative mx-auto w-full" style={{ maxWidth: 640 }}>
-      {/* Screen frame */}
+      {/* Screen frame — persistent, never animates */}
       <div
         className="relative overflow-hidden"
         style={{
@@ -63,40 +65,55 @@ function HudScreen({ project }: { project: Project }) {
           transformOrigin: "center center",
         }}
       >
-        {/* Media */}
-        <div className="relative aspect-video bg-black">
-          {hasImage ? (
-            <Image
-              src={project.images[0]}
-              alt={project.title}
-              fill
-              className="object-cover opacity-90"
-              sizes="(max-width: 768px) 100vw, 55vw"
+        {/* Media — only this transitions between projects */}
+        {project.banners ? (
+          <BannerShowcase banners={project.banners} />
+        ) : (
+          <div className="relative aspect-video bg-black">
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={project.key}
+                className="absolute inset-0"
+                initial={{ opacity: 0, filter: "brightness(1.8)" }}
+                animate={{ opacity: 1, filter: "brightness(1)" }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.18 }}
+              >
+                {hasImage ? (
+                  <Image
+                    src={project.images[0]}
+                    alt={project.title}
+                    fill
+                    className="object-cover opacity-90"
+                    sizes="(max-width: 768px) 100vw, 55vw"
+                  />
+                ) : (
+                  <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-blue-950 to-indigo-950">
+                    <BloombergLogo className="w-40 max-h-10 object-contain opacity-50" />
+                  </div>
+                )}
+              </motion.div>
+            </AnimatePresence>
+
+            {/* Scanlines */}
+            <div
+              className="absolute inset-0 pointer-events-none z-10"
+              style={{
+                backgroundImage:
+                  "repeating-linear-gradient(to bottom, transparent 0px, transparent 2px, rgba(0,0,0,0.1) 2px, rgba(0,0,0,0.1) 3px)",
+              }}
             />
-          ) : (
-            <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-blue-950 to-indigo-950">
-              <BloombergLogo className="w-40 max-h-10 object-contain opacity-50" />
-            </div>
-          )}
 
-          {/* Scanlines */}
-          <div
-            className="absolute inset-0 pointer-events-none z-10"
-            style={{
-              backgroundImage:
-                "repeating-linear-gradient(to bottom, transparent 0px, transparent 2px, rgba(0,0,0,0.1) 2px, rgba(0,0,0,0.1) 3px)",
-            }}
-          />
-
-          {/* Vignette */}
-          <div
-            className="absolute inset-0 pointer-events-none z-10"
-            style={{
-              background:
-                "radial-gradient(ellipse at center, transparent 35%, rgba(0,0,4,0.55) 100%)",
-            }}
-          />
-        </div>
+            {/* Vignette */}
+            <div
+              className="absolute inset-0 pointer-events-none z-10"
+              style={{
+                background:
+                  "radial-gradient(ellipse at center, transparent 35%, rgba(0,0,4,0.55) 100%)",
+              }}
+            />
+          </div>
+        )}
 
         {/* Status bar */}
         <div
@@ -166,37 +183,14 @@ export default function ProjectsGallery() {
 
         {/* ── LEFT: HUD Screen ── */}
         <div className="md:w-[55%] flex items-center justify-center p-6 md:p-10 md:pl-8 shrink-0">
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={project.key + "-screen"}
-              className="w-full"
-              initial={{ opacity: 0, scale: 0.97 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.97 }}
-              transition={{ duration: 0.45 }}
-            >
-              {project.banners ? (
-                // Bloomberg: BannerShowcase in place of the HUD screen
-                <div
-                  className="overflow-hidden"
-                  style={{
-                    borderRadius: "4px 20px 8px 6px",
-                    border: "1px solid color-mix(in srgb, var(--zone-accent) 38%, transparent)",
-                    boxShadow: "0 0 48px color-mix(in srgb, var(--zone-accent) 14%, transparent)",
-                  }}
-                >
-                  <BannerShowcase banners={project.banners} />
-                </div>
-              ) : (
-                <HudScreen project={project} />
-              )}
-            </motion.div>
-          </AnimatePresence>
+          <div className="w-full">
+            <HudScreen project={project} />
+          </div>
         </div>
 
         {/* ── RIGHT: Project info + index ── */}
         <div
-          className="flex-1 flex flex-col justify-center overflow-y-auto px-6 md:px-8 pb-6 md:py-10 border-t md:border-t-0 md:border-l border-white/8"
+          className="flex-1 flex flex-col justify-start md:justify-center overflow-y-auto px-6 md:px-8 pt-4 pb-6 md:py-10 border-t md:border-t-0 md:border-l border-white/8"
           style={{ scrollbarWidth: "none" }}
         >
           <AnimatePresence mode="wait">
@@ -240,7 +234,7 @@ export default function ProjectsGallery() {
               </p>
 
               {/* Description */}
-              <p className="text-white/60 text-sm leading-relaxed mb-4 line-clamp-3">
+              <p className="text-white/60 text-sm leading-relaxed mb-4 line-clamp-4 md:line-clamp-3">
                 {project.description}
               </p>
 

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -17,7 +17,7 @@ import { BloombergLogo } from "./ClientLogos";
 
 const N = projectsData.length;
 const NAV_H = 64;
-const ITEM_H = 52; // px — height of each rolling list row
+const ITEM_H = 40; // px — height of each rolling list row (title only, no description)
 const VISIBLE = 5; // rows visible in the rolling list
 
 // ── Corner bracket decorations ─────────────────────────────────────────────────
@@ -283,8 +283,13 @@ export default function ProjectsGallery() {
               </div>
 
               {/* Client */}
-              <p className="text-sm mb-3" style={{ color: "var(--zone-accent)" }}>
+              <p className="text-sm mb-2" style={{ color: "var(--zone-accent)" }}>
                 {project.client}
+              </p>
+
+              {/* Description */}
+              <p className="text-white/55 text-sm leading-relaxed mb-3 line-clamp-2">
+                {project.description}
               </p>
 
               {/* Tech pills */}
@@ -306,18 +311,18 @@ export default function ProjectsGallery() {
 
           {/* Rolling project list */}
           <div
-            className="relative overflow-hidden shrink-0"
+            className="relative overflow-hidden shrink-0 rounded-xl"
             style={{ height: ITEM_H * VISIBLE }}
           >
             {/* Fade top */}
             <div
               className="absolute inset-x-0 top-0 z-10 pointer-events-none"
-              style={{ height: ITEM_H * 1.2, background: "linear-gradient(to bottom, #000408, transparent)" }}
+              style={{ height: ITEM_H * 2, background: "linear-gradient(to bottom, #000408 30%, transparent)" }}
             />
             {/* Fade bottom */}
             <div
               className="absolute inset-x-0 bottom-0 z-10 pointer-events-none"
-              style={{ height: ITEM_H * 1.2, background: "linear-gradient(to top, #000408, transparent)" }}
+              style={{ height: ITEM_H * 2, background: "linear-gradient(to top, #000408 30%, transparent)" }}
             />
 
             <motion.div
@@ -327,7 +332,7 @@ export default function ProjectsGallery() {
               {projectsData.map((p, i) => {
                 const dist = Math.abs(i - activeIdx);
                 const isActive = i === activeIdx;
-                const opacity = isActive ? 1 : dist === 1 ? 0.45 : 0.15;
+                const opacity = isActive ? 1 : dist === 1 ? 0.5 : 0.18;
                 return (
                   <motion.div
                     key={p.key}
@@ -335,22 +340,17 @@ export default function ProjectsGallery() {
                     transition={{ duration: 0.3 }}
                     style={{ height: ITEM_H, cursor: "pointer" }}
                     onClick={() => scrollToProject(i)}
-                    className="flex flex-col justify-center gap-0.5 select-none"
+                    className={`flex items-center gap-2.5 px-2 rounded-lg select-none ${isActive ? "bg-white/5" : ""}`}
                   >
-                    <div className="flex items-center gap-2">
-                      <span
-                        className="font-mono text-[10px] tabular-nums shrink-0"
-                        style={{ color: isActive ? "var(--zone-accent)" : "rgba(255,255,255,0.35)" }}
-                      >
-                        {String(i + 1).padStart(2, "0")}
-                      </span>
-                      <span className={`text-sm font-semibold leading-tight truncate ${isActive ? "text-white" : "text-white/60"}`}>
-                        {p.title}
-                      </span>
-                    </div>
-                    <p className="text-[11px] text-white/30 line-clamp-1 leading-snug pl-6">
-                      {p.description}
-                    </p>
+                    <span
+                      className="font-mono text-[10px] tabular-nums shrink-0"
+                      style={{ color: isActive ? "var(--zone-accent)" : "rgba(255,255,255,0.35)" }}
+                    >
+                      {String(i + 1).padStart(2, "0")}
+                    </span>
+                    <span className={`text-sm leading-tight truncate ${isActive ? "text-white font-semibold" : "text-white/60 font-medium"}`}>
+                      {p.title}
+                    </span>
                   </motion.div>
                 );
               })}

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -281,7 +281,7 @@ export default function ProjectsGallery() {
 
         {/* ── RIGHT: Project info + rolling list ── */}
         <div
-          className="flex-1 flex flex-col justify-start md:justify-center overflow-hidden px-6 md:px-8 pt-4 pb-6 md:py-10 border-t md:border-t-0 md:border-l border-white/8"
+          className="flex-1 flex flex-col justify-start md:justify-center px-6 md:px-8 pt-4 pb-6 md:py-10 border-t md:border-t-0 md:border-l border-white/8"
         >
           {/* Info block — animates on project change */}
           <AnimatePresence mode="wait">
@@ -351,19 +351,8 @@ export default function ProjectsGallery() {
             className="relative overflow-hidden shrink-0"
             style={{ height: ITEM_H * VISIBLE }}
           >
-            {/* Fade top */}
-            <div
-              className="absolute inset-x-0 top-0 z-10 pointer-events-none"
-              style={{ height: ITEM_H * 2, background: "linear-gradient(to bottom, #000408 30%, transparent)" }}
-            />
-            {/* Fade bottom */}
-            <div
-              className="absolute inset-x-0 bottom-0 z-10 pointer-events-none"
-              style={{ height: ITEM_H * 2, background: "linear-gradient(to top, #000408 30%, transparent)" }}
-            />
-
             <motion.div
-              animate={{ y: Math.floor(VISIBLE / 2) * ITEM_H - activeIdx * ITEM_H }}
+              animate={{ y: -activeIdx * ITEM_H }}
               transition={{ type: "spring", stiffness: 280, damping: 38, mass: 0.8 }}
             >
               {projectsData.map((p, i) => {

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { projectsData, type Project } from "@/data/projects";
 import BannerShowcase from "./BannerShowcase";
 import { FaGithub, FaExternalLinkAlt, FaChevronLeft, FaChevronRight } from "react-icons/fa";
@@ -11,6 +11,8 @@ import {
   useScroll,
   useTransform,
   useSpring,
+  useMotionValue,
+  useMotionTemplate,
   useMotionValueEvent,
 } from "framer-motion";
 import { BloombergLogo } from "./ClientLogos";
@@ -53,14 +55,47 @@ interface HudScreenProps {
   onImageChange: (i: number) => void;
 }
 
+// Base desktop tilt — leans the screen toward the info/list panel on the right
+const TILT_BASE = { x: 4, y: 8 };
+
 function HudScreen({ project, imageIdx, onPrev, onNext, onImageChange }: HudScreenProps) {
   const hasImages = project.images.length > 0;
   const hasMultiple = project.images.length > 1;
 
+  const tiltX = useMotionValue(0);
+  const tiltY = useMotionValue(0);
+  const springX = useSpring(tiltX, { stiffness: 280, damping: 22 });
+  const springY = useSpring(tiltY, { stiffness: 280, damping: 22 });
+  const tiltTransform = useMotionTemplate`perspective(900px) rotateY(${springY}deg) rotateX(${springX}deg) translateY(-6px)`;
+
+  // Apply base desktop tilt after mount (avoids SSR mismatch)
+  useEffect(() => {
+    if (window.matchMedia("(min-width: 768px)").matches) {
+      tiltX.set(TILT_BASE.x);
+      tiltY.set(TILT_BASE.y);
+    }
+  }, [tiltX, tiltY]);
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!window.matchMedia("(min-width: 768px)").matches) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const nx = ((e.clientX - rect.left) / rect.width) * 2 - 1;  // -1 … 1
+    const ny = ((e.clientY - rect.top) / rect.height) * 2 - 1;
+    tiltY.set(TILT_BASE.y + nx * 5);   // ±5 deg horizontal
+    tiltX.set(TILT_BASE.x - ny * 4);   // ±4 deg vertical (inverted: cursor up → tilt back)
+  };
+
+  const handleMouseLeave = () => {
+    tiltX.set(TILT_BASE.x);
+    tiltY.set(TILT_BASE.y);
+  };
+
   return (
-    <div
-      className="relative mx-auto w-full md:[transform:perspective(900px)_rotateY(8deg)_rotateX(4deg)_translateY(-6px)] md:[transform-origin:center_center]"
-      style={{ maxWidth: 640, cursor: "default" }}
+    <motion.div
+      className="relative mx-auto w-full"
+      style={{ maxWidth: 640, cursor: "default", transform: tiltTransform }}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
     >
       {/* Screen frame */}
       <div
@@ -173,7 +208,7 @@ function HudScreen({ project, imageIdx, onPrev, onNext, onImageChange }: HudScre
       </div>
 
       <ScreenBrackets />
-    </div>
+    </motion.div>
   );
 }
 

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -58,7 +58,7 @@ function HudScreen({ project, imageIdx, onPrev, onNext, onImageChange }: HudScre
   const hasMultiple = project.images.length > 1;
 
   return (
-    <div className="relative mx-auto w-full" style={{ maxWidth: 640 }}>
+    <div className="relative mx-auto w-full" style={{ maxWidth: 640, cursor: "default" }}>
       {/* Screen frame — persistent, never animates */}
       <div
         className="relative overflow-hidden"

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -58,11 +58,13 @@ function HudScreen({ project, imageIdx, onPrev, onNext, onImageChange }: HudScre
   const hasMultiple = project.images.length > 1;
 
   return (
-    <div className="relative mx-auto w-full" style={{ maxWidth: 640, cursor: "default" }}>
-      {/* Screen frame — persistent, never animates */}
+    <div
+      className="relative mx-auto w-full md:[transform:perspective(900px)_rotateY(8deg)_rotateX(4deg)_translateY(-6px)] md:[transform-origin:center_center]"
+      style={{ maxWidth: 640, cursor: "default" }}
+    >
+      {/* Screen frame */}
       <div
         className="relative overflow-hidden"
-        className="md:[transform:perspective(900px)_rotateY(8deg)_rotateX(4deg)_translateY(-6px)] md:[transform-origin:center_center]"
         style={{
           borderRadius: "4px 20px 8px 6px",
           border: "1px solid color-mix(in srgb, var(--zone-accent) 38%, transparent)",

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -68,34 +68,29 @@ function HudScreen({ project, imageIdx, onPrev, onNext, onImageChange }: HudScre
   const springY = useSpring(tiltY, { stiffness: 280, damping: 22 });
   const tiltTransform = useMotionTemplate`perspective(900px) rotateY(${springY}deg) rotateX(${springX}deg) translateY(-6px)`;
 
-  // Apply base desktop tilt after mount (avoids SSR mismatch)
+  // Track cursor anywhere on the viewport and tilt the screen toward it
   useEffect(() => {
-    if (window.matchMedia("(min-width: 768px)").matches) {
-      tiltX.set(TILT_BASE.x);
-      tiltY.set(TILT_BASE.y);
-    }
-  }, [tiltX, tiltY]);
+    const isDesktop = window.matchMedia("(min-width: 768px)").matches;
+    if (!isDesktop) return;
 
-  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (!window.matchMedia("(min-width: 768px)").matches) return;
-    const rect = e.currentTarget.getBoundingClientRect();
-    const nx = ((e.clientX - rect.left) / rect.width) * 2 - 1;  // -1 … 1
-    const ny = ((e.clientY - rect.top) / rect.height) * 2 - 1;
-    tiltY.set(TILT_BASE.y + nx * 5);   // ±5 deg horizontal
-    tiltX.set(TILT_BASE.x - ny * 4);   // ±4 deg vertical (inverted: cursor up → tilt back)
-  };
-
-  const handleMouseLeave = () => {
     tiltX.set(TILT_BASE.x);
     tiltY.set(TILT_BASE.y);
-  };
+
+    const onMove = (e: MouseEvent) => {
+      const nx = (e.clientX / window.innerWidth) * 2 - 1;   // -1 … 1
+      const ny = (e.clientY / window.innerHeight) * 2 - 1;
+      tiltY.set(TILT_BASE.y + nx * 5);
+      tiltX.set(TILT_BASE.x - ny * 4);
+    };
+
+    window.addEventListener("mousemove", onMove, { passive: true });
+    return () => window.removeEventListener("mousemove", onMove);
+  }, [tiltX, tiltY]);
 
   return (
     <motion.div
       className="relative mx-auto w-full"
       style={{ maxWidth: 640, cursor: "default", transform: tiltTransform }}
-      onMouseMove={handleMouseMove}
-      onMouseLeave={handleMouseLeave}
     >
       {/* Screen frame */}
       <div

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -200,13 +200,15 @@ export default function ProjectsGallery() {
   const handlePrev = () => setImageIdx((i) => (i === 0 ? images.length - 1 : i - 1));
   const handleNext = () => setImageIdx((i) => (i === images.length - 1 ? 0 : i + 1));
 
-  // Scroll to the position that makes project `idx` the active one
+  // Scroll to the midpoint of project `idx`'s scroll range.
+  // Targeting the exact boundary (idx/N) lands rawIdx just below idx due to the
+  // [0, N-0.0001] transform, so Math.floor gives idx-1. Midpoint is always safe.
   const scrollToProject = (idx: number) => {
     const el = sectionRef.current;
     if (!el) return;
     const top = el.getBoundingClientRect().top + window.scrollY;
     const h = el.offsetHeight;
-    const target = top + (idx / N) * Math.max(h - window.innerHeight, 0);
+    const target = top + ((idx + 0.5) / N) * Math.max(h - window.innerHeight, 0);
     window.scrollTo({ top: Math.max(0, target), behavior: "smooth" });
   };
 

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -62,14 +62,20 @@ function HudScreen({ project, imageIdx, onPrev, onNext, onImageChange }: HudScre
       {/* Screen frame — persistent, never animates */}
       <div
         className="relative overflow-hidden"
-        className="md:[transform:perspective(1200px)_rotateX(3deg)] md:[transform-origin:center_top]"
+        className="md:[transform:perspective(900px)_rotateY(8deg)_rotateX(4deg)_translateY(-6px)] md:[transform-origin:center_center]"
         style={{
           borderRadius: "4px 20px 8px 6px",
           border: "1px solid color-mix(in srgb, var(--zone-accent) 38%, transparent)",
           boxShadow: [
-            "0 0 48px color-mix(in srgb, var(--zone-accent) 14%, transparent)",
-            "0 0 0 1px color-mix(in srgb, var(--zone-accent) 6%, transparent)",
-            "inset 0 0 24px rgba(0,0,4,0.6)",
+            // Accent glow
+            "0 0 48px color-mix(in srgb, var(--zone-accent) 16%, transparent)",
+            "0 0 0 1px color-mix(in srgb, var(--zone-accent) 8%, transparent)",
+            // Inner depth
+            "inset 0 0 32px rgba(0,0,4,0.7)",
+            // Elevation shadows — simulate lifted surface
+            "0 40px 80px -12px rgba(0,0,4,0.95)",
+            "0 20px 40px -8px rgba(0,0,0,0.75)",
+            "0 8px 16px -2px rgba(0,0,0,0.5)",
           ].join(", "),
         }}
       >

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import { useState, useRef } from "react";
 import { projectsData, type Project } from "@/data/projects";
 import BannerShowcase from "./BannerShowcase";
-import { FaGithub, FaExternalLinkAlt } from "react-icons/fa";
+import { FaGithub, FaExternalLinkAlt, FaChevronLeft, FaChevronRight } from "react-icons/fa";
 import {
   motion,
   AnimatePresence,
@@ -17,8 +17,10 @@ import { BloombergLogo } from "./ClientLogos";
 
 const N = projectsData.length;
 const NAV_H = 64;
+const ITEM_H = 52; // px — height of each rolling list row
+const VISIBLE = 5; // rows visible in the rolling list
 
-// ── Corner bracket decorations for the HUD screen ─────────────────────────────
+// ── Corner bracket decorations ─────────────────────────────────────────────────
 function ScreenBrackets() {
   const c = "var(--zone-accent)";
   const base: React.CSSProperties = { position: "absolute", opacity: 0.55, pointerEvents: "none" };
@@ -43,10 +45,17 @@ function ScreenBrackets() {
 }
 
 // ── HUD terminal screen ────────────────────────────────────────────────────────
-// The outer frame is always present; only the media content inside transitions
-// (channel-change effect — the TV stays on, the channel switches).
-function HudScreen({ project }: { project: Project }) {
-  const hasImage = project.images.length > 0;
+interface HudScreenProps {
+  project: Project;
+  imageIdx: number;
+  onPrev: () => void;
+  onNext: () => void;
+  onImageChange: (i: number) => void;
+}
+
+function HudScreen({ project, imageIdx, onPrev, onNext, onImageChange }: HudScreenProps) {
+  const hasImages = project.images.length > 0;
+  const hasMultiple = project.images.length > 1;
 
   return (
     <div className="relative mx-auto w-full" style={{ maxWidth: 640 }}>
@@ -65,24 +74,24 @@ function HudScreen({ project }: { project: Project }) {
           transformOrigin: "center center",
         }}
       >
-        {/* Media — only this transitions between projects */}
+        {/* Media — only this transitions between projects / images */}
         {project.banners ? (
           <BannerShowcase banners={project.banners} />
         ) : (
           <div className="relative aspect-video bg-black">
             <AnimatePresence mode="wait">
               <motion.div
-                key={project.key}
+                key={`${project.key}-${imageIdx}`}
                 className="absolute inset-0"
                 initial={{ opacity: 0, filter: "brightness(1.8)" }}
                 animate={{ opacity: 1, filter: "brightness(1)" }}
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.18 }}
               >
-                {hasImage ? (
+                {hasImages ? (
                   <Image
-                    src={project.images[0]}
-                    alt={project.title}
+                    src={project.images[imageIdx]}
+                    alt={`${project.title} screenshot ${imageIdx + 1}`}
                     fill
                     className="object-cover opacity-90"
                     sizes="(max-width: 768px) 100vw, 55vw"
@@ -103,15 +112,42 @@ function HudScreen({ project }: { project: Project }) {
                   "repeating-linear-gradient(to bottom, transparent 0px, transparent 2px, rgba(0,0,0,0.1) 2px, rgba(0,0,0,0.1) 3px)",
               }}
             />
-
             {/* Vignette */}
             <div
               className="absolute inset-0 pointer-events-none z-10"
-              style={{
-                background:
-                  "radial-gradient(ellipse at center, transparent 35%, rgba(0,0,4,0.55) 100%)",
-              }}
+              style={{ background: "radial-gradient(ellipse at center, transparent 35%, rgba(0,0,4,0.55) 100%)" }}
             />
+
+            {/* Image navigation (multi-image projects only) */}
+            {hasMultiple && (
+              <>
+                <button
+                  onClick={onPrev}
+                  className="absolute left-2 bottom-2 z-20 p-1.5 rounded bg-black/50 hover:bg-black/70 text-white/50 hover:text-white transition-colors cursor-pointer"
+                  aria-label="Previous image"
+                >
+                  <FaChevronLeft size={11} />
+                </button>
+                <button
+                  onClick={onNext}
+                  className="absolute right-2 bottom-2 z-20 p-1.5 rounded bg-black/50 hover:bg-black/70 text-white/50 hover:text-white transition-colors cursor-pointer"
+                  aria-label="Next image"
+                >
+                  <FaChevronRight size={11} />
+                </button>
+                <div className="absolute bottom-2.5 left-1/2 -translate-x-1/2 flex gap-1 z-20">
+                  {project.images.map((_, di) => (
+                    <button
+                      key={di}
+                      onClick={() => onImageChange(di)}
+                      className="w-1 h-1 rounded-full transition-colors cursor-pointer"
+                      style={{ background: di === imageIdx ? "rgba(255,255,255,0.9)" : "rgba(255,255,255,0.25)" }}
+                      aria-label={`Image ${di + 1}`}
+                    />
+                  ))}
+                </div>
+              </>
+            )}
           </div>
         )}
 
@@ -123,17 +159,12 @@ function HudScreen({ project }: { project: Project }) {
             borderTop: "1px solid color-mix(in srgb, var(--zone-accent) 18%, transparent)",
           }}
         >
-          <span className="opacity-50" style={{ color: "var(--zone-accent)" }}>
-            ◈ SYS.DISPLAY
-          </span>
-          <span className="text-white/25 uppercase tracking-widest">
-            {project.key.replace(/_/g, ".")}
-          </span>
+          <span className="opacity-50" style={{ color: "var(--zone-accent)" }}>◈ SYS.DISPLAY</span>
+          <span className="text-white/25 uppercase tracking-widest">{project.key.replace(/_/g, ".")}</span>
           <span className="ml-auto text-white/20 tracking-widest">VISUAL.OUT</span>
         </div>
       </div>
 
-      {/* Corner bracket decorations */}
       <ScreenBrackets />
     </div>
   );
@@ -142,6 +173,7 @@ function HudScreen({ project }: { project: Project }) {
 // ── Main gallery ───────────────────────────────────────────────────────────────
 export default function ProjectsGallery() {
   const [activeIdx, setActiveIdx] = useState(0);
+  const [imageIdx, setImageIdx] = useState(0);
   const sectionRef = useRef<HTMLDivElement>(null);
 
   const { scrollYProgress } = useScroll({
@@ -153,14 +185,32 @@ export default function ProjectsGallery() {
 
   useMotionValueEvent(rawIdx, "change", (v) => {
     const next = Math.floor(v);
-    setActiveIdx((prev) => (prev !== next ? next : prev));
+    setActiveIdx((prev) => {
+      if (prev === next) return prev;
+      setImageIdx(0); // reset image carousel on project change
+      return next;
+    });
   });
 
   const springProgress = useSpring(scrollYProgress, { stiffness: 100, damping: 30 });
 
   const project = projectsData[activeIdx];
-  const counterStr =
-    String(activeIdx + 1).padStart(2, "0") + " / " + String(N).padStart(2, "0");
+  const images = project.images;
+
+  const handlePrev = () => setImageIdx((i) => (i === 0 ? images.length - 1 : i - 1));
+  const handleNext = () => setImageIdx((i) => (i === images.length - 1 ? 0 : i + 1));
+
+  // Scroll to the position that makes project `idx` the active one
+  const scrollToProject = (idx: number) => {
+    const el = sectionRef.current;
+    if (!el) return;
+    const top = el.getBoundingClientRect().top + window.scrollY;
+    const h = el.offsetHeight;
+    const target = top + (idx / N) * Math.max(h - window.innerHeight, 0);
+    window.scrollTo({ top: Math.max(0, target), behavior: "smooth" });
+  };
+
+  const counterStr = String(activeIdx + 1).padStart(2, "0") + " / " + String(N).padStart(2, "0");
 
   return (
     <div ref={sectionRef} style={{ height: `${N * 80}vh` }}>
@@ -173,37 +223,39 @@ export default function ProjectsGallery() {
         <div className="absolute left-0 top-0 bottom-0 w-0.5 z-20 overflow-hidden">
           <motion.div
             className="absolute inset-x-0 top-0 bottom-0 opacity-50"
-            style={{
-              background: "var(--zone-accent)",
-              scaleY: springProgress,
-              transformOrigin: "top",
-            }}
+            style={{ background: "var(--zone-accent)", scaleY: springProgress, transformOrigin: "top" }}
           />
         </div>
 
         {/* ── LEFT: HUD Screen ── */}
         <div className="md:w-[55%] flex items-center justify-center p-6 md:p-10 md:pl-8 shrink-0">
           <div className="w-full">
-            <HudScreen project={project} />
+            <HudScreen
+              project={project}
+              imageIdx={imageIdx}
+              onPrev={handlePrev}
+              onNext={handleNext}
+              onImageChange={setImageIdx}
+            />
           </div>
         </div>
 
-        {/* ── RIGHT: Project info + index ── */}
+        {/* ── RIGHT: Project info + rolling list ── */}
         <div
-          className="flex-1 flex flex-col justify-start md:justify-center overflow-y-auto px-6 md:px-8 pt-4 pb-6 md:py-10 border-t md:border-t-0 md:border-l border-white/8"
-          style={{ scrollbarWidth: "none" }}
+          className="flex-1 flex flex-col justify-start md:justify-center overflow-hidden px-6 md:px-8 pt-4 pb-6 md:py-10 border-t md:border-t-0 md:border-l border-white/8"
         >
+          {/* Info block — animates on project change */}
           <AnimatePresence mode="wait">
             <motion.div
               key={project.key + "-info"}
               initial={{ opacity: 0, y: 14 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -10 }}
-              transition={{ duration: 0.38 }}
+              transition={{ duration: 0.35 }}
               className="shrink-0"
             >
               {/* Counter */}
-              <p className="font-mono text-xs tracking-widest mb-4" style={{ color: "var(--zone-accent)", opacity: 0.6 }}>
+              <p className="font-mono text-xs tracking-widest mb-3" style={{ color: "var(--zone-accent)", opacity: 0.6 }}>
                 {counterStr}
               </p>
 
@@ -233,11 +285,6 @@ export default function ProjectsGallery() {
                 {project.client}
               </p>
 
-              {/* Description */}
-              <p className="text-white/60 text-sm leading-relaxed mb-4 line-clamp-4 md:line-clamp-3">
-                {project.description}
-              </p>
-
               {/* Tech pills */}
               <div className="flex flex-wrap gap-2">
                 {project.technologies.map((tech) => (
@@ -253,23 +300,59 @@ export default function ProjectsGallery() {
           </AnimatePresence>
 
           {/* Divider */}
-          <div className="h-px bg-white/8 my-5 shrink-0" />
+          <div className="h-px bg-white/8 my-4 shrink-0" />
 
-          {/* Project index — inactive items */}
-          <div className="flex flex-col gap-0.5 overflow-y-auto shrink-0" style={{ scrollbarWidth: "none" }}>
-            {projectsData.map((p, i) => (
-              <motion.div
-                key={p.key}
-                animate={{ opacity: i === activeIdx ? 0 : 0.3 }}
-                transition={{ duration: 0.3 }}
-                className="py-1"
-              >
-                <span className="font-mono text-[10px] text-white/40 mr-2 tabular-nums">
-                  {String(i + 1).padStart(2, "0")}
-                </span>
-                <span className="text-white text-xs font-medium">{p.title}</span>
-              </motion.div>
-            ))}
+          {/* Rolling project list */}
+          <div
+            className="relative overflow-hidden shrink-0"
+            style={{ height: ITEM_H * VISIBLE }}
+          >
+            {/* Fade top */}
+            <div
+              className="absolute inset-x-0 top-0 z-10 pointer-events-none"
+              style={{ height: ITEM_H * 1.2, background: "linear-gradient(to bottom, #000408, transparent)" }}
+            />
+            {/* Fade bottom */}
+            <div
+              className="absolute inset-x-0 bottom-0 z-10 pointer-events-none"
+              style={{ height: ITEM_H * 1.2, background: "linear-gradient(to top, #000408, transparent)" }}
+            />
+
+            <motion.div
+              animate={{ y: Math.floor(VISIBLE / 2) * ITEM_H - activeIdx * ITEM_H }}
+              transition={{ type: "spring", stiffness: 280, damping: 38, mass: 0.8 }}
+            >
+              {projectsData.map((p, i) => {
+                const dist = Math.abs(i - activeIdx);
+                const isActive = i === activeIdx;
+                const opacity = isActive ? 1 : dist === 1 ? 0.45 : 0.15;
+                return (
+                  <motion.div
+                    key={p.key}
+                    animate={{ opacity }}
+                    transition={{ duration: 0.3 }}
+                    style={{ height: ITEM_H, cursor: "pointer" }}
+                    onClick={() => scrollToProject(i)}
+                    className="flex flex-col justify-center gap-0.5 select-none"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="font-mono text-[10px] tabular-nums shrink-0"
+                        style={{ color: isActive ? "var(--zone-accent)" : "rgba(255,255,255,0.35)" }}
+                      >
+                        {String(i + 1).padStart(2, "0")}
+                      </span>
+                      <span className={`text-sm font-semibold leading-tight truncate ${isActive ? "text-white" : "text-white/60"}`}>
+                        {p.title}
+                      </span>
+                    </div>
+                    <p className="text-[11px] text-white/30 line-clamp-1 leading-snug pl-6">
+                      {p.description}
+                    </p>
+                  </motion.div>
+                );
+              })}
+            </motion.div>
           </div>
         </div>
       </div>

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -62,6 +62,7 @@ function HudScreen({ project, imageIdx, onPrev, onNext, onImageChange }: HudScre
       {/* Screen frame — persistent, never animates */}
       <div
         className="relative overflow-hidden"
+        className="md:[transform:perspective(1100px)_rotateY(-6deg)_rotateX(2deg)] md:[transform-origin:center_center]"
         style={{
           borderRadius: "4px 20px 8px 6px",
           border: "1px solid color-mix(in srgb, var(--zone-accent) 38%, transparent)",
@@ -70,8 +71,6 @@ function HudScreen({ project, imageIdx, onPrev, onNext, onImageChange }: HudScre
             "0 0 0 1px color-mix(in srgb, var(--zone-accent) 6%, transparent)",
             "inset 0 0 24px rgba(0,0,4,0.6)",
           ].join(", "),
-          transform: "perspective(1100px) rotateY(-6deg) rotateX(2deg)",
-          transformOrigin: "center center",
         }}
       >
         {/* Media — only this transitions between projects / images */}

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -1,213 +1,284 @@
 "use client";
 
 import Image from "next/image";
-import { useState, useEffect, useRef } from "react";
+import { useState, useRef } from "react";
 import { projectsData, type Project } from "@/data/projects";
 import BannerShowcase from "./BannerShowcase";
-import { FaGithub, FaExternalLinkAlt, FaChevronLeft, FaChevronRight } from "react-icons/fa";
-import { motion, AnimatePresence } from "framer-motion";
+import { FaGithub, FaExternalLinkAlt } from "react-icons/fa";
+import {
+  motion,
+  AnimatePresence,
+  useScroll,
+  useTransform,
+  useSpring,
+  useMotionValueEvent,
+} from "framer-motion";
 import { BloombergLogo } from "./ClientLogos";
 
-// ── Image carousel ────────────────────────────────────────────────────────────
-function ImageCarousel({ images, title }: { images: string[]; title: string }) {
-  const [idx, setIdx] = useState(0);
-  const prev = () => setIdx((i) => (i === 0 ? images.length - 1 : i - 1));
-  const next = () => setIdx((i) => (i === images.length - 1 ? 0 : i + 1));
+const N = projectsData.length;
+const NAV_H = 64;
 
+// ── Corner bracket decorations for the HUD screen ─────────────────────────────
+function ScreenBrackets() {
+  const c = "var(--zone-accent)";
+  const base: React.CSSProperties = { position: "absolute", opacity: 0.55, pointerEvents: "none" };
+  const s = 18;
+  const w = 1.5;
   return (
-    <div className="relative w-full aspect-video bg-black/30 rounded-xl overflow-hidden">
-      <AnimatePresence mode="wait">
-        <motion.div
-          key={idx}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.25 }}
-          className="absolute inset-0"
-        >
-          <Image src={images[idx]} alt={`${title} screenshot ${idx + 1}`} fill className="object-cover opacity-85" />
-          <div className="absolute inset-0 bg-blue-950/25 mix-blend-multiply pointer-events-none" />
-          <div className="absolute inset-0 pointer-events-none" style={{ background: "radial-gradient(ellipse at center, transparent 40%, rgba(2,8,23,0.6) 100%)" }} />
-        </motion.div>
-      </AnimatePresence>
-
-      {images.length > 1 && (
-        <>
-          <button onClick={prev} className="absolute left-2 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white rounded-full p-2 transition-colors" aria-label="Previous image">
-            <FaChevronLeft size={14} />
-          </button>
-          <button onClick={next} className="absolute right-2 top-1/2 -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white rounded-full p-2 transition-colors" aria-label="Next image">
-            <FaChevronRight size={14} />
-          </button>
-          <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex gap-1.5">
-            {images.map((_, i) => (
-              <button key={i} onClick={() => setIdx(i)} className={`w-1.5 h-1.5 rounded-full transition-colors ${i === idx ? "bg-white" : "bg-white/40"}`} aria-label={`Go to image ${i + 1}`} />
-            ))}
-          </div>
-        </>
-      )}
-    </div>
+    <>
+      <svg style={{ ...base, top: -9, left: -9 }} width={s} height={s} viewBox="0 0 18 18">
+        <path d="M0 12 L0 0 L12 0" fill="none" stroke={c} strokeWidth={w} />
+      </svg>
+      <svg style={{ ...base, top: -9, right: -9 }} width={s} height={s} viewBox="0 0 18 18">
+        <path d="M18 12 L18 0 L6 0" fill="none" stroke={c} strokeWidth={w} />
+      </svg>
+      <svg style={{ ...base, bottom: -9, left: -9 }} width={s} height={s} viewBox="0 0 18 18">
+        <path d="M0 6 L0 18 L12 18" fill="none" stroke={c} strokeWidth={w} />
+      </svg>
+      <svg style={{ ...base, bottom: -9, right: -9 }} width={s} height={s} viewBox="0 0 18 18">
+        <path d="M18 6 L18 18 L6 18" fill="none" stroke={c} strokeWidth={w} />
+      </svg>
+    </>
   );
 }
 
-// ── Featured panel ────────────────────────────────────────────────────────────
-function FeaturedPanel({ project, onPrev, onNext }: { project: Project; onPrev: () => void; onNext: () => void }) {
-  return (
-    <div className="clip-tr-lg bg-white/5 border border-white/10 overflow-hidden flex flex-col h-full">
-      {/* Media */}
-      <div className="shrink-0">
-        {project.banners
-          ? <BannerShowcase banners={project.banners} />
-          : <ImageCarousel images={project.images} title={project.title} />
-        }
-      </div>
-
-      {/* Details */}
-      <div className="p-6 flex flex-col flex-1">
-        <div className="flex items-start justify-between gap-3 mb-1">
-          <h3 className="text-white font-bold text-xl">{project.title}</h3>
-          <div className="flex gap-3 shrink-0">
-            {project.sourceCode && (
-              <a href={project.sourceCode} target="_blank" rel="noopener noreferrer" className="text-white/50 hover:text-white transition-colors" aria-label="Source code">
-                <FaGithub size={18} />
-              </a>
-            )}
-            {project.deployment && (
-              <a href={project.deployment} target="_blank" rel="noopener noreferrer" className="text-white/50 hover:text-white transition-colors" aria-label="Live site">
-                <FaExternalLinkAlt size={16} />
-              </a>
-            )}
-          </div>
-        </div>
-
-        <p className="text-blue-300 text-sm mb-3">{project.client}</p>
-        <p className="text-white/70 text-sm leading-relaxed mb-4 flex-1">{project.description}</p>
-
-        <div className="flex flex-wrap gap-2 mb-5">
-          {project.technologies.map((tech) => (
-            <span key={tech} className="text-xs px-2.5 py-1 bg-blue-500/15 text-blue-300 rounded-full border border-blue-500/20">
-              {tech}
-            </span>
-          ))}
-        </div>
-
-        {/* Prev / Next */}
-        <div className="flex gap-2 pt-4 border-t border-white/8">
-          <button onClick={onPrev} className="flex items-center gap-1.5 text-white/40 hover:text-white text-xs transition-colors cursor-pointer">
-            <FaChevronLeft size={11} /> Prev
-          </button>
-          <button onClick={onNext} className="flex items-center gap-1.5 text-white/40 hover:text-white text-xs transition-colors ml-auto cursor-pointer">
-            Next <FaChevronRight size={11} />
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ── Filmstrip item ────────────────────────────────────────────────────────────
-function FilmstripItem({ project, active, onClick }: { project: Project; active: boolean; onClick: () => void }) {
-  const thumb = project.images[0] ?? null;
+// ── HUD terminal screen ────────────────────────────────────────────────────────
+function HudScreen({ project }: { project: Project }) {
+  const hasImage = project.images.length > 0;
 
   return (
-    <button
-      onClick={onClick}
-      className={`w-full shrink-0 group text-left transition-all duration-200 rounded-xl overflow-hidden border cursor-pointer ${
-        active
-          ? "border-blue-400/60 bg-white/8 shadow-lg shadow-blue-500/10"
-          : "border-white/8 bg-white/3 hover:border-white/20 hover:bg-white/6"
-      }`}
-    >
-      {/* Thumbnail — fixed aspect ratio so all items are same height */}
-      <div className="relative w-full bg-black/30 overflow-hidden" style={{ paddingTop: "56.25%" }}>
-        <div className="absolute inset-0">
-          {thumb ? (
-            <Image src={thumb} alt={project.title} fill className={`object-cover transition-opacity duration-200 ${active ? "opacity-90" : "opacity-50 group-hover:opacity-70"}`} />
+    <div className="relative mx-auto w-full" style={{ maxWidth: 640 }}>
+      {/* Screen frame */}
+      <div
+        className="relative overflow-hidden"
+        style={{
+          borderRadius: "4px 20px 8px 6px",
+          border: "1px solid color-mix(in srgb, var(--zone-accent) 38%, transparent)",
+          boxShadow: [
+            "0 0 48px color-mix(in srgb, var(--zone-accent) 14%, transparent)",
+            "0 0 0 1px color-mix(in srgb, var(--zone-accent) 6%, transparent)",
+            "inset 0 0 24px rgba(0,0,4,0.6)",
+          ].join(", "),
+          transform: "perspective(1100px) rotateY(-6deg) rotateX(2deg)",
+          transformOrigin: "center center",
+        }}
+      >
+        {/* Media */}
+        <div className="relative aspect-video bg-black">
+          {hasImage ? (
+            <Image
+              src={project.images[0]}
+              alt={project.title}
+              fill
+              className="object-cover opacity-90"
+              sizes="(max-width: 768px) 100vw, 55vw"
+            />
           ) : (
-            <div className={`absolute inset-0 flex items-center justify-center bg-linear-to-br from-blue-950 to-indigo-950 px-6 transition-opacity duration-200 ${active ? "opacity-90" : "opacity-50 group-hover:opacity-70"}`}>
-              {project.key === "bloomberg"
-                ? <BloombergLogo className="w-full max-h-8 object-contain" />
-                : <span className="text-white/20 text-2xl font-bold">{project.client.charAt(0)}</span>
-              }
+            <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-blue-950 to-indigo-950">
+              <BloombergLogo className="w-40 max-h-10 object-contain opacity-50" />
             </div>
           )}
+
+          {/* Scanlines */}
+          <div
+            className="absolute inset-0 pointer-events-none z-10"
+            style={{
+              backgroundImage:
+                "repeating-linear-gradient(to bottom, transparent 0px, transparent 2px, rgba(0,0,0,0.1) 2px, rgba(0,0,0,0.1) 3px)",
+            }}
+          />
+
+          {/* Vignette */}
+          <div
+            className="absolute inset-0 pointer-events-none z-10"
+            style={{
+              background:
+                "radial-gradient(ellipse at center, transparent 35%, rgba(0,0,4,0.55) 100%)",
+            }}
+          />
         </div>
-        {active && <div className="absolute inset-0 ring-2 ring-inset ring-blue-400/40" />}
+
+        {/* Status bar */}
+        <div
+          className="flex items-center gap-3 px-3 py-1.5 text-[10px] font-mono shrink-0"
+          style={{
+            background: "color-mix(in srgb, var(--zone-accent) 5%, #000408)",
+            borderTop: "1px solid color-mix(in srgb, var(--zone-accent) 18%, transparent)",
+          }}
+        >
+          <span className="opacity-50" style={{ color: "var(--zone-accent)" }}>
+            ◈ SYS.DISPLAY
+          </span>
+          <span className="text-white/25 uppercase tracking-widest">
+            {project.key.replace(/_/g, ".")}
+          </span>
+          <span className="ml-auto text-white/20 tracking-widest">VISUAL.OUT</span>
+        </div>
       </div>
 
-      {/* Label — fixed height so all items align */}
-      <div className="px-3 py-2.5 h-13 flex flex-col justify-center">
-        <p className={`text-xs font-semibold leading-tight line-clamp-1 transition-colors ${active ? "text-white" : "text-white/55 group-hover:text-white/80"}`}>
-          {project.title}
-        </p>
-        <p className={`text-xs mt-0.5 truncate transition-colors ${active ? "text-blue-300/80" : "text-white/30 group-hover:text-white/45"}`}>
-          {project.client}
-        </p>
-      </div>
-    </button>
+      {/* Corner bracket decorations */}
+      <ScreenBrackets />
+    </div>
   );
 }
 
-// ── Main component ────────────────────────────────────────────────────────────
+// ── Main gallery ───────────────────────────────────────────────────────────────
 export default function ProjectsGallery() {
   const [activeIdx, setActiveIdx] = useState(0);
-  const total   = projectsData.length;
-  const prev    = () => setActiveIdx((i) => (i === 0 ? total - 1 : i - 1));
-  const next    = () => setActiveIdx((i) => (i === total - 1 ? 0 : i + 1));
+  const sectionRef = useRef<HTMLDivElement>(null);
+
+  const { scrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: ["start start", "end end"],
+  });
+
+  const rawIdx = useTransform(scrollYProgress, [0, 1], [0, N - 0.0001]);
+
+  useMotionValueEvent(rawIdx, "change", (v) => {
+    const next = Math.floor(v);
+    setActiveIdx((prev) => (prev !== next ? next : prev));
+  });
+
+  const springProgress = useSpring(scrollYProgress, { stiffness: 100, damping: 30 });
+
   const project = projectsData[activeIdx];
-
-  const filmstripRef = useRef<HTMLDivElement>(null);
-  const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
-
-  useEffect(() => {
-    const container = filmstripRef.current;
-    const item = itemRefs.current[activeIdx];
-    if (!container || !item) return;
-
-    const containerBox = container.getBoundingClientRect();
-    const itemBox = item.getBoundingClientRect();
-    const isVertical = container.scrollHeight > container.clientHeight;
-
-    if (isVertical) {
-      const offset = itemBox.top - containerBox.top - containerBox.height / 2 + itemBox.height / 2;
-      container.scrollBy({ top: offset, behavior: "smooth" });
-    } else {
-      const offset = itemBox.left - containerBox.left - containerBox.width / 2 + itemBox.width / 2;
-      container.scrollBy({ left: offset, behavior: "smooth" });
-    }
-  }, [activeIdx]);
+  const counterStr =
+    String(activeIdx + 1).padStart(2, "0") + " / " + String(N).padStart(2, "0");
 
   return (
-    <div className="flex flex-col lg:flex-row gap-5">
-
-      {/* ── Featured panel ── */}
-      <div className="flex-1 min-w-0">
-        <AnimatePresence mode="wait">
-          <motion.div
-            key={project.key}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.18 }}
-            className="h-full"
-          >
-            <FeaturedPanel project={project} onPrev={prev} onNext={next} />
-          </motion.div>
-        </AnimatePresence>
-      </div>
-
-      {/* ── Filmstrip ── */}
-      {/* Mobile: horizontal scroll row. Desktop: vertical scrollable column. */}
-      <div ref={filmstripRef} className="flex flex-row lg:flex-col gap-3 overflow-x-auto lg:overflow-x-hidden lg:overflow-y-auto lg:w-56 xl:w-64 pb-2 lg:pb-0 lg:max-h-160 shrink-0"
-        style={{ scrollbarWidth: "none" }}
+    <div ref={sectionRef} style={{ height: `${N * 80}vh` }}>
+      {/* ── Sticky panel ── */}
+      <div
+        className="sticky flex flex-col md:flex-row overflow-hidden"
+        style={{ top: NAV_H, height: `calc(100svh - ${NAV_H}px)` }}
       >
-        {projectsData.map((p, i) => (
-          <div key={p.key} ref={el => { itemRefs.current[i] = el; }} className="w-44 lg:w-auto shrink-0">
-            <FilmstripItem project={p} active={i === activeIdx} onClick={() => setActiveIdx(i)} />
-          </div>
-        ))}
-      </div>
+        {/* Scroll progress bar — left edge */}
+        <div className="absolute left-0 top-0 bottom-0 w-0.5 z-20 overflow-hidden">
+          <motion.div
+            className="absolute inset-x-0 top-0 bottom-0 opacity-50"
+            style={{
+              background: "var(--zone-accent)",
+              scaleY: springProgress,
+              transformOrigin: "top",
+            }}
+          />
+        </div>
 
+        {/* ── LEFT: HUD Screen ── */}
+        <div className="md:w-[55%] flex items-center justify-center p-6 md:p-10 md:pl-8 shrink-0">
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={project.key + "-screen"}
+              className="w-full"
+              initial={{ opacity: 0, scale: 0.97 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.97 }}
+              transition={{ duration: 0.45 }}
+            >
+              {project.banners ? (
+                // Bloomberg: BannerShowcase in place of the HUD screen
+                <div
+                  className="overflow-hidden"
+                  style={{
+                    borderRadius: "4px 20px 8px 6px",
+                    border: "1px solid color-mix(in srgb, var(--zone-accent) 38%, transparent)",
+                    boxShadow: "0 0 48px color-mix(in srgb, var(--zone-accent) 14%, transparent)",
+                  }}
+                >
+                  <BannerShowcase banners={project.banners} />
+                </div>
+              ) : (
+                <HudScreen project={project} />
+              )}
+            </motion.div>
+          </AnimatePresence>
+        </div>
+
+        {/* ── RIGHT: Project info + index ── */}
+        <div
+          className="flex-1 flex flex-col justify-center overflow-y-auto px-6 md:px-8 pb-6 md:py-10 border-t md:border-t-0 md:border-l border-white/8"
+          style={{ scrollbarWidth: "none" }}
+        >
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={project.key + "-info"}
+              initial={{ opacity: 0, y: 14 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -10 }}
+              transition={{ duration: 0.38 }}
+              className="shrink-0"
+            >
+              {/* Counter */}
+              <p className="font-mono text-xs tracking-widest mb-4" style={{ color: "var(--zone-accent)", opacity: 0.6 }}>
+                {counterStr}
+              </p>
+
+              {/* Title + links */}
+              <div className="flex items-start justify-between gap-3 mb-1">
+                <h3 className="text-white font-bold text-2xl md:text-3xl leading-tight">
+                  {project.title}
+                </h3>
+                <div className="flex gap-3 shrink-0 pt-1">
+                  {project.sourceCode && (
+                    <a href={project.sourceCode} target="_blank" rel="noopener noreferrer"
+                      className="text-white/40 hover:text-white transition-colors" aria-label="Source code">
+                      <FaGithub size={18} />
+                    </a>
+                  )}
+                  {project.deployment && (
+                    <a href={project.deployment} target="_blank" rel="noopener noreferrer"
+                      className="text-white/40 hover:text-white transition-colors" aria-label="Live site">
+                      <FaExternalLinkAlt size={15} />
+                    </a>
+                  )}
+                </div>
+              </div>
+
+              {/* Client */}
+              <p className="text-sm mb-3" style={{ color: "var(--zone-accent)" }}>
+                {project.client}
+              </p>
+
+              {/* Description */}
+              <p className="text-white/60 text-sm leading-relaxed mb-4 line-clamp-3">
+                {project.description}
+              </p>
+
+              {/* Tech pills */}
+              <div className="flex flex-wrap gap-2">
+                {project.technologies.map((tech) => (
+                  <span
+                    key={tech}
+                    className="text-xs px-2.5 py-1 bg-blue-500/15 text-blue-300 rounded-full border border-blue-500/20"
+                  >
+                    {tech}
+                  </span>
+                ))}
+              </div>
+            </motion.div>
+          </AnimatePresence>
+
+          {/* Divider */}
+          <div className="h-px bg-white/8 my-5 shrink-0" />
+
+          {/* Project index — inactive items */}
+          <div className="flex flex-col gap-0.5 overflow-y-auto shrink-0" style={{ scrollbarWidth: "none" }}>
+            {projectsData.map((p, i) => (
+              <motion.div
+                key={p.key}
+                animate={{ opacity: i === activeIdx ? 0 : 0.3 }}
+                transition={{ duration: 0.3 }}
+                className="py-1"
+              >
+                <span className="font-mono text-[10px] text-white/40 mr-2 tabular-nums">
+                  {String(i + 1).padStart(2, "0")}
+                </span>
+                <span className="text-white text-xs font-medium">{p.title}</span>
+              </motion.div>
+            ))}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -16,6 +16,7 @@ import {
   useMotionValueEvent,
 } from "framer-motion";
 import { BloombergLogo } from "./ClientLogos";
+import Modal from "./Modal";
 
 const N = projectsData.length;
 const NAV_H = 64;
@@ -211,6 +212,7 @@ function HudScreen({ project, imageIdx, onPrev, onNext, onImageChange }: HudScre
 export default function ProjectsGallery() {
   const [activeIdx, setActiveIdx] = useState(0);
   const [imageIdx, setImageIdx] = useState(0);
+  const [descModal, setDescModal] = useState(false);
   const sectionRef = useRef<HTMLDivElement>(null);
 
   const { scrollYProgress } = useScroll({
@@ -230,6 +232,10 @@ export default function ProjectsGallery() {
   });
 
   const springProgress = useSpring(scrollYProgress, { stiffness: 100, damping: 30 });
+
+  // Close modal on project change
+  useEffect(() => { setDescModal(false); }, [activeIdx]);
+
 
   const project = projectsData[activeIdx];
   const images = project.images;
@@ -267,7 +273,8 @@ export default function ProjectsGallery() {
         </div>
 
         {/* ── LEFT: HUD Screen ── */}
-        <div className="md:w-[55%] flex items-center justify-center p-6 md:p-10 md:pl-8 shrink-0">
+        {/* max-h-[52%] on mobile caps the HUD so the info panel always gets the rest of the viewport */}
+        <div className="md:w-[55%] max-h-[52%] md:max-h-none flex items-center justify-center p-4 md:p-10 md:pl-8 shrink-0 overflow-hidden">
           <div className="w-full">
             <HudScreen
               project={project}
@@ -325,9 +332,16 @@ export default function ProjectsGallery() {
               </p>
 
               {/* Description */}
-              <p className="text-white/55 text-sm leading-relaxed mb-3 line-clamp-2">
+              <p className="text-white/55 text-sm leading-relaxed line-clamp-2 md:line-clamp-4 mb-1">
                 {project.description}
               </p>
+              <button
+                onClick={() => setDescModal(true)}
+                className="text-xs font-semibold mb-3 tracking-wide"
+                style={{ color: "var(--zone-accent)", cursor: "pointer" }}
+              >
+                more ↗
+              </button>
 
               {/* Tech pills */}
               <div className="flex flex-wrap gap-2">
@@ -384,6 +398,49 @@ export default function ProjectsGallery() {
           </div>
         </div>
       </div>
+
+      {/* ── Description modal ── */}
+      <Modal isOpen={descModal} onClose={() => setDescModal(false)}>
+        <div
+          className="w-full max-w-md max-h-[70vh] flex flex-col rounded-xl overflow-hidden"
+          style={{
+            background: "color-mix(in srgb, var(--zone-accent) 6%, #020c18)",
+            border: "1px solid color-mix(in srgb, var(--zone-accent) 25%, transparent)",
+            boxShadow: "0 24px 64px rgba(0,0,0,0.7)",
+          }}
+        >
+          {/* Header */}
+          <div
+            className="flex items-center justify-between px-5 py-3 shrink-0"
+            style={{ borderBottom: "1px solid color-mix(in srgb, var(--zone-accent) 18%, transparent)" }}
+          >
+            <span className="text-white font-semibold text-sm">{project.title}</span>
+            <button
+              onClick={() => setDescModal(false)}
+              className="text-white/40 hover:text-white transition-colors text-lg leading-none"
+              style={{ cursor: "pointer" }}
+              aria-label="Close"
+            >
+              ✕
+            </button>
+          </div>
+
+          {/* Scrollable body */}
+          <div className="overflow-y-auto px-5 py-4 space-y-4">
+            <p className="text-white/70 text-sm leading-relaxed">{project.description}</p>
+            <div className="flex flex-wrap gap-2">
+              {project.technologies.map((tech) => (
+                <span
+                  key={tech}
+                  className="text-xs px-2.5 py-1 bg-blue-500/15 text-blue-300 rounded-full border border-blue-500/20"
+                >
+                  {tech}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -348,7 +348,7 @@ export default function ProjectsGallery() {
 
           {/* Rolling project list */}
           <div
-            className="relative overflow-hidden shrink-0 rounded-xl"
+            className="relative overflow-hidden shrink-0"
             style={{ height: ITEM_H * VISIBLE }}
           >
             {/* Fade top */}
@@ -377,7 +377,7 @@ export default function ProjectsGallery() {
                     transition={{ duration: 0.3 }}
                     style={{ height: ITEM_H, cursor: "pointer" }}
                     onClick={() => scrollToProject(i)}
-                    className={`flex items-center gap-2.5 px-2 rounded-lg select-none ${isActive ? "bg-white/5" : ""}`}
+                    className="flex items-center gap-2.5 select-none"
                   >
                     <span
                       className="font-mono text-[10px] tabular-nums shrink-0"

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -1,14 +1,15 @@
-import DepthSection from "@/components/ocean/DepthSection";
 import DepthLabel from "@/components/ocean/DepthLabel";
-import { ProjectsGallery } from "@/components/ClientOnly";
 import SectionHeading from "@/components/SectionHeading";
+import { ProjectsGallery } from "@/components/ClientOnly";
 
 export default function ProjectsSection() {
   return (
-    <DepthSection id="projects">
-      <DepthLabel depth="~500m" />
-      <SectionHeading title="Projects" subtitle="Things I've built" />
+    <section id="projects" className="relative">
+      <div className="px-6 md:px-16 pt-24 pb-10 max-w-5xl mx-auto">
+        <DepthLabel depth="~500m" />
+        <SectionHeading title="Projects" subtitle="Things I've built" />
+      </div>
       <ProjectsGallery />
-    </DepthSection>
+    </section>
   );
 }

--- a/src/components/ocean/HeroElements.tsx
+++ b/src/components/ocean/HeroElements.tsx
@@ -78,6 +78,7 @@ function CursorFish() {
   const _dir = useMemo(() => new THREE.Vector3(), []);
   const cursor = useRef({ x: 0, y: 0 });
   const prevWorld = useRef(new THREE.Vector2());
+  const prevNDC   = useRef({ x: 0, y: 0 });
   const smoothAngle = useRef(0);
   const isClickable = useRef(false);
   const glow = useRef(0);
@@ -258,17 +259,37 @@ function CursorFish() {
         py = wy;
       }
 
-      const vx = px - prevWorld.current.x;
-      const vy = py - prevWorld.current.y;
-      const speed = Math.min(Math.sqrt(vx * vx + vy * vy) / delta, 150);
+      // World-space delta — used only during handoff when the fish is traveling to the cursor
+      const dwx = px - prevWorld.current.x;
+      const dwy = py - prevWorld.current.y;
       prevWorld.current.set(px, py);
 
-      if (speed > 0.3) {
-        const target = Math.atan2(vy, vx);
-        let diff = target - smoothAngle.current;
-        while (diff >  Math.PI) diff -= Math.PI * 2;
-        while (diff < -Math.PI) diff += Math.PI * 2;
-        smoothAngle.current += diff * Math.min(delta * 12, 1);
+      // NDC-space delta — cursor viewport position, unaffected by camera scroll
+      const ndcDx = cursor.current.x - prevNDC.current.x;
+      const ndcDy = cursor.current.y - prevNDC.current.y;
+      prevNDC.current.x = cursor.current.x;
+      prevNDC.current.y = cursor.current.y;
+
+      if (elapsed < HANDOFF_DUR) {
+        // During handoff the fish travels to the cursor — world velocity drives rotation
+        const speed = Math.min(Math.sqrt(dwx * dwx + dwy * dwy) / delta, 150);
+        if (speed > 0.3) {
+          const target = Math.atan2(dwy, dwx);
+          let diff = target - smoothAngle.current;
+          while (diff >  Math.PI) diff -= Math.PI * 2;
+          while (diff < -Math.PI) diff += Math.PI * 2;
+          smoothAngle.current += diff * Math.min(delta * 12, 1);
+        }
+      } else {
+        // Normal cursor following — use NDC delta so camera Y scroll (e.g. projects sticky
+        // section) doesn't affect the fish's facing direction and reveal the page scroll
+        if (Math.abs(ndcDx) > 0.0005 || Math.abs(ndcDy) > 0.0005) {
+          const target = Math.atan2(ndcDy, ndcDx);
+          let diff = target - smoothAngle.current;
+          while (diff >  Math.PI) diff -= Math.PI * 2;
+          while (diff < -Math.PI) diff += Math.PI * 2;
+          smoothAngle.current += diff * Math.min(delta * 12, 1);
+        }
       }
 
       fishRef.current.position.set(px, py, 2);

--- a/src/components/ocean/HeroElements.tsx
+++ b/src/components/ocean/HeroElements.tsx
@@ -78,7 +78,6 @@ function CursorFish() {
   const _dir = useMemo(() => new THREE.Vector3(), []);
   const cursor = useRef({ x: 0, y: 0 });
   const prevWorld = useRef(new THREE.Vector2());
-  const prevNDC   = useRef({ x: 0, y: 0 });
   const smoothAngle = useRef(0);
   const isClickable = useRef(false);
   const glow = useRef(0);
@@ -259,37 +258,17 @@ function CursorFish() {
         py = wy;
       }
 
-      // World-space delta — used only during handoff when the fish is traveling to the cursor
-      const dwx = px - prevWorld.current.x;
-      const dwy = py - prevWorld.current.y;
+      const vx = px - prevWorld.current.x;
+      const vy = py - prevWorld.current.y;
+      const speed = Math.min(Math.sqrt(vx * vx + vy * vy) / delta, 150);
       prevWorld.current.set(px, py);
 
-      // NDC-space delta — cursor viewport position, unaffected by camera scroll
-      const ndcDx = cursor.current.x - prevNDC.current.x;
-      const ndcDy = cursor.current.y - prevNDC.current.y;
-      prevNDC.current.x = cursor.current.x;
-      prevNDC.current.y = cursor.current.y;
-
-      if (elapsed < HANDOFF_DUR) {
-        // During handoff the fish travels to the cursor — world velocity drives rotation
-        const speed = Math.min(Math.sqrt(dwx * dwx + dwy * dwy) / delta, 150);
-        if (speed > 0.3) {
-          const target = Math.atan2(dwy, dwx);
-          let diff = target - smoothAngle.current;
-          while (diff >  Math.PI) diff -= Math.PI * 2;
-          while (diff < -Math.PI) diff += Math.PI * 2;
-          smoothAngle.current += diff * Math.min(delta * 12, 1);
-        }
-      } else {
-        // Normal cursor following — use NDC delta so camera Y scroll (e.g. projects sticky
-        // section) doesn't affect the fish's facing direction and reveal the page scroll
-        if (Math.abs(ndcDx) > 0.0005 || Math.abs(ndcDy) > 0.0005) {
-          const target = Math.atan2(ndcDy, ndcDx);
-          let diff = target - smoothAngle.current;
-          while (diff >  Math.PI) diff -= Math.PI * 2;
-          while (diff < -Math.PI) diff += Math.PI * 2;
-          smoothAngle.current += diff * Math.min(delta * 12, 1);
-        }
+      if (speed > 0.3) {
+        const target = Math.atan2(vy, vx);
+        let diff = target - smoothAngle.current;
+        while (diff >  Math.PI) diff -= Math.PI * 2;
+        while (diff < -Math.PI) diff += Math.PI * 2;
+        smoothAngle.current += diff * Math.min(delta * 12, 1);
       }
 
       fishRef.current.position.set(px, py, 2);

--- a/src/components/ocean/OceanScene.tsx
+++ b/src/components/ocean/OceanScene.tsx
@@ -97,19 +97,51 @@ function BioParticles({ count = 600 }: { count?: number }) {
 export default function OceanScene() {
   const { camera, gl } = useThree();
 
-  const getScrollProgress = () => {
-    const el = document.documentElement;
-    const p = el.scrollTop / (el.scrollHeight - el.clientHeight);
-    return isNaN(p) ? 0 : p;
+  // Measure the projects section so we can freeze the camera while scrolling through it.
+  // That section's scroll drives the project list only — not ocean depth.
+  const projectsRange = useRef<{ top: number; height: number } | null>(null);
+  useEffect(() => {
+    const measure = () => {
+      const el = document.getElementById("projects");
+      if (!el) return;
+      projectsRange.current = {
+        top: Math.round(el.getBoundingClientRect().top + window.scrollY),
+        height: el.offsetHeight,
+      };
+    };
+    const t = setTimeout(measure, 120); // after layout settles
+    window.addEventListener("resize", measure, { passive: true });
+    return () => { clearTimeout(t); window.removeEventListener("resize", measure); };
+  }, []);
+
+  // Returns a scroll progress value with the projects section's scroll range subtracted.
+  // Camera and background color freeze at the entry depth while inside that section.
+  const getAdjustedProgress = () => {
+    const docEl = document.documentElement;
+    const scrollTop = docEl.scrollTop;
+    const totalRange = docEl.scrollHeight - docEl.clientHeight;
+    if (totalRange === 0) return 0;
+    const pr = projectsRange.current;
+    if (!pr) return Math.min(scrollTop / totalRange, 1);
+    const projEnd = pr.top + pr.height;
+    let eff: number;
+    if (scrollTop <= pr.top) {
+      eff = scrollTop;
+    } else if (scrollTop >= projEnd) {
+      eff = pr.top + (scrollTop - projEnd);
+    } else {
+      eff = pr.top; // frozen — inside projects section
+    }
+    return Math.min(eff / Math.max(totalRange - pr.height, 1), 1);
   };
 
-  const [scrollProgress, setScrollProgress] = useState(getScrollProgress);
-  const targetCamY  = useRef(-getScrollProgress() * SCROLL_DEPTH_SCALE);
-  const currentCamY = useRef(-getScrollProgress() * SCROLL_DEPTH_SCALE);
+  const [scrollProgress, setScrollProgress] = useState(getAdjustedProgress);
+  const targetCamY  = useRef(-getAdjustedProgress() * SCROLL_DEPTH_SCALE);
+  const currentCamY = useRef(-getAdjustedProgress() * SCROLL_DEPTH_SCALE);
 
   useEffect(() => {
     const onScroll = () => {
-      const progress = getScrollProgress();
+      const progress = getAdjustedProgress();
       setScrollProgress(progress);
       targetCamY.current = -progress * SCROLL_DEPTH_SCALE;
     };


### PR DESCRIPTION
## Summary

- Rewrites the Projects section as a scroll-driven sticky showcase: scrolling advances a project index while the ocean background freezes
- HUD terminal screen shows project images/banners with channel-change transitions and cursor-driven 3D tilt on desktop
- Rolling drum list with spring animation, active project pinned to top, click to jump
- Description modal (with tech pills) replaces inline truncation — modal restores cursor so the fish cursor doesn't hide the pointer
- Shared Modal component bakes in cursor restoration and Escape-to-close for all future modals
- Mobile: HUD capped at 52% viewport height so info panel always has room
- Ocean camera and background color freeze during projects scroll range
- Fixes bloomberg banner 404 (missing public/bloomberg/index.css)

## Test plan

- [ ] Scroll through projects section — index advances, ocean stays frozen
- [ ] Click a list item — scrolls to correct project (no off-by-one)
- [ ] Image carousel prev/next and dots work; resets on project change
- [ ] more arrow opens modal with full description and tech pills; closes on X, backdrop click, or Escape
- [ ] Cursor is visible (default) inside the modal
- [ ] Desktop: HUD tilts as cursor moves across viewport
- [ ] Mobile small screen: info panel visible below HUD, more button not hidden
- [ ] Bloomberg banners load without 404 errors in console

Generated with [Claude Code](https://claude.com/claude-code)