### PR TITLE
Mobile nav redesign + projects panel overhaul

### DIFF
--- a/.claude/commands/nav.md
+++ b/.claude/commands/nav.md
@@ -1,0 +1,55 @@
+You are working on the `NavBar` component at `src/components/NavBar.tsx`. Here is the critical context you need before making any changes.
+
+## Structure
+
+The navbar renders two things inside a fragment:
+1. `<motion.nav>` — fixed top bar, always visible, fades in on mount after HUD is ready
+2. A fullscreen mobile menu overlay (`AnimatePresence` controlled by `mobileOpen`)
+
+It only renders once `useHudVisible()` returns true (waits for the ocean HUD to appear so the nav doesn't flash before the scene is ready).
+
+## Zone color system
+
+The `--zone-accent` CSS variable drives all nav accent colors (underlines, index numbers, active pip, scan lines). It is set by `ZoneColorSync` elsewhere in the app based on scroll depth. The nav reads the same depth scale to display a zone label:
+
+```ts
+const DEPTH_STOPS = [0, 0.18, 0.38, 0.57, 0.74, 1];
+const DEPTH_VALS  = [0,   50,  200,  500, 1000, 3800]; // meters
+// zoneName: SUNLIGHT → TWILIGHT → MIDNIGHT → ABYSSAL → HADAL
+```
+
+The zone name appears in the desktop nav (right of links, `lg:` breakpoint only) and in the mobile menu footer.
+
+## Desktop nav
+
+- BK badge: `BkBadge` component (SVG with scan-line boot animation, corner brackets spring in/out on hover). Desktop only — mobile gets `StaticBkBadge` with tap-triggered brackets.
+- Nav links: `NavLinkItem` — vertical text slide on hover, shared `layoutId="nav-underline"` animates the active underline between items.
+- Section spy via `IntersectionObserver` with `-40% 0px -55% 0px` root margin.
+
+## Mobile menu
+
+Full-screen takeover, clip-path wipe animation (`inset(0 0 100% 0)` → `inset(0 0 0% 0)`). Large typographic nav list (text-5xl) with staggered entry.
+
+**Scroll behavior on short viewports:** Links live in `overflow-y-auto` + `min-h-0` scroll container with an inner `min-h-full justify-center` div. This centers content when it fits and scrolls without clipping when the viewport is short. Do not collapse this back to a single `justify-center` div.
+
+**Selection flow:** `handleMobileNavClick` runs two timers:
+- 320ms → close menu (icon reverts to hamburger simultaneously)
+- 700ms → scroll to section + clear `selectedHref`
+
+The gap lets the scan-line sweep play before the curtain closes, and lets the curtain mostly close before the page scrolls.
+
+## Hamburger icon — `MenuIcon`
+
+Custom animated 3-line → X component. Three `motion.span` lines, staggered widths at rest (22/15/11px). On open: lines grow to equalize width, converge to center, middle fades, outer two rotate ±45°. On close: reverse. **Do not replace with an icon library icon** — the animation timing is carefully tuned.
+
+## Scroll lock
+
+`useScrollLock(mobileOpen)` from `src/hooks/useScrollLock.ts` handles body scroll lock when the mobile menu is open. The `Modal` component handles its own scroll lock independently. They do not conflict.
+
+## Key hooks used
+
+- `useScrollLock` — `src/hooks/useScrollLock.ts`
+- `useHudVisible` — `src/hooks/useHudVisible.ts`
+- `useMotionValueEvent`, `useScroll`, `useTransform` from framer-motion for live depth
+
+$ARGUMENTS

--- a/.claude/commands/ocean-design-system.md
+++ b/.claude/commands/ocean-design-system.md
@@ -1,0 +1,88 @@
+You are working on the billykaufman-v2 portfolio. Before touching any UI, read this context on the design system.
+
+## Core concept — "painted on top of a scene"
+
+This is NOT a document-layout site. The UI is a HUD/console overlay rendered on top of a Three.js ocean scene. Think instrument panels and submarine consoles, not cards and grids.
+
+Rules that follow from this:
+- No box shadows that suggest floating material cards
+- No rounded-lg / rounded-xl generic radii — use `clip-tr`, `clip-bl`, `clip-tr-bl` (irregular console corners defined in globals.css)
+- No white backgrounds or light themes
+- Spacing and layout should feel structural, not decorative
+
+## The zone color system
+
+`--zone-accent` is a CSS variable set on `:root` by `ZoneColorSync` based on scroll depth. It changes as the user dives through ocean zones:
+
+| Zone | Color |
+|------|-------|
+| Sunlight (0–50m) | `#67e8f9` cyan |
+| Twilight (50–200m) | blue |
+| Midnight (200–500m) | deeper blue |
+| Abyssal (500–1000m) | indigo/violet |
+| Hadal (1000m+) | deep violet |
+
+**Always use `var(--zone-accent)` for interactive accents, underlines, active states, and HUD elements.** Never hardcode a blue/cyan color for accent purposes — the zone system will look wrong at depth.
+
+## Typography
+
+- Font: Raleway (primary), Inter (fallback), system-ui
+- HUD labels / counters: `font-mono`, small, `tracking-widest`, low opacity (0.3–0.6)
+- Body copy: Raleway, `text-white/70`
+- Never use serif fonts
+
+## globals.css — key classes
+
+```css
+/* Irregular console corners */
+.clip-tr     { border-radius: 4px 20px 8px 6px; }   /* top-right prominent */
+.clip-tr-lg  { border-radius: 6px 32px 12px 8px; }
+.clip-bl     { border-radius: 8px 6px 4px 20px; }   /* bottom-left prominent */
+.clip-bl-lg  { border-radius: 10px 8px 6px 32px; }
+.clip-tr-bl  { border-radius: 4px 20px 8px 20px; }  /* both prominent */
+
+/* Scrollbars — native scrollbar is globally hidden */
+/* Add .styled-scrollbar to elements that need a visible thin scrollbar */
+.styled-scrollbar { ... } /* uses --zone-accent at 30% opacity */
+
+/* Animated gradients */
+.btn-cta      { animated multi-stop gradient button }
+.name-shimmer { shimmer text effect for hero name }
+.marquee-track { infinite horizontal scroll }
+```
+
+**Important:** `::-webkit-scrollbar { width: 0 }` hides ALL scrollbars globally. If an element needs a scrollbar, give it `className="styled-scrollbar"` — the class selector overrides the element selector.
+
+## Three.js / ocean scene
+
+- Entry: `src/components/ocean/` — do not modify unless explicitly working on the 3D scene
+- `HeroElements.tsx` — ambient orbs + cursor fish (desktop only, hidden on touch devices)
+- The cursor fish replaces the OS cursor (`cursor: none` on body) — every modal/overlay must restore it with `style={{ cursor: "default" }}`. The `Modal` component already does this.
+- Canvas background: `#000408` — set on both `html` and `body` to prevent iOS safe-area gaps
+
+## iOS / mobile constraints (do NOT undo these)
+
+- `html { touch-action: pan-y; overscroll-behavior-x: none; }` — prevents horizontal swipe-back interference
+- `overflow-x: hidden` is on `body`, NOT `html` — Safari treats it on html as hiding both axes which kills touch scrolling
+- `scroll-behavior: smooth` is removed from CSS — iOS intercepts it on first touch. Use `scrollIntoView({ behavior: 'smooth' })` in JS instead
+- Native scrollbar hidden globally via `::-webkit-scrollbar { width: 0 }` — replaced by HUD DepthGauge
+
+## HUD screen component pattern
+
+The `HudScreen` in `ProjectsGallery` is the canonical example of a "console screen":
+- Irregular border radius (`clip-tr`)
+- `border: 1px solid color-mix(in srgb, var(--zone-accent) 38%, transparent)`
+- Box shadow stack: accent glow + inner depth shadow + elevation shadows
+- Scanline overlay (`repeating-linear-gradient`) + radial vignette
+- Status bar at bottom: `font-mono`, tiny, dark background tinted with zone accent
+- `ScreenBrackets` SVG corner decorations
+
+## Constants and data
+
+- `src/constants/urls.ts` — all external URLs (never hardcode URLs inline)
+- `src/data/projects.ts` — project entries
+- `src/data/experience.ts` — work history
+- `src/data/clients.ts` — client logos for marquee
+- `src/data/social.ts` — social links
+
+$ARGUMENTS

--- a/.claude/commands/projects-gallery.md
+++ b/.claude/commands/projects-gallery.md
@@ -1,0 +1,67 @@
+You are working on the `ProjectsGallery` component at `src/components/ProjectsGallery.tsx`. Here is the critical context you need before making any changes.
+
+## What it does
+
+A scroll-driven project showcase. The section is `N * 80vh` tall — the user scrolls through it while a sticky panel stays fixed. Each "screen-height worth" of scroll corresponds to one project.
+
+## Key constants
+
+```ts
+const N = projectsData.length;        // total project count
+const NAV_H = 64;                      // navbar height in px
+const ITEM_H = 40;                     // px height of each compact (non-active) list row
+```
+
+## Scroll math
+
+`scrollYProgress` from framer-motion maps `[0, 1]` across the full section height.
+
+Active project index: `Math.floor(v * (N - 0.0001))` — the small epsilon prevents the index from ever reaching `N` exactly at `v=1`.
+
+`scrollToProject(idx)` targets `idx + 0.4` within its band (not the exact boundary `idx/N`, which can land one project early due to float rounding):
+```ts
+const target = top + ((idx + 0.4) / N) * Math.max(h - window.innerHeight, 0);
+```
+
+## Resize handling
+
+`isResizing` ref freezes the `useMotionValueEvent` listener during resize so `activeIdx` doesn't flicker. `activeIdxRef` (a ref mirroring `activeIdx`) lets the resize effect read the current project without a stale closure. Both refs are declared before `useMotionValueEvent`.
+
+After 200ms of no resize events, the handler restores scroll position with `behavior: "instant"`.
+
+## MotionValue subscription rule
+
+**Always pass `tiltTransform` to `style.transform` from the first render.** Conditionally passing a MotionValue breaks framer-motion's subscription. On mobile, zero out `tiltX`/`tiltY` instead of removing the prop.
+
+## Right panel — sector32 list pattern
+
+The list scrolls so the active item is always at top: `animate={{ y: -activeIdx * ITEM_H }}`. This works because all items before the active one are always exactly `ITEM_H` tall (compact rows). The active item expands in-place with full info — counter, title, client, tech pills, "Read more" button.
+
+Non-active compact rows are `<button>` elements (not `div`) for accessibility, with `aria-label`.
+
+## Data
+
+Projects live in `src/data/projects.ts`. The `Project` type:
+```ts
+type Project = {
+  key: string;
+  title: string;
+  client: string;
+  technologies: string[];
+  description: string;
+  images: string[];       // empty array = no screenshots (use placeholder)
+  banners?: BannerSize[]; // Bloomberg-style iframe showcase instead of image
+  sourceCode?: string;
+  deployment?: string;
+};
+```
+
+## Description modal
+
+"Read more" opens a `Modal` (see `src/components/Modal.tsx`) with full description + all tech pills. Modal is dismissed on Escape, backdrop click, or the ✕ button. Body scroll is locked while open (handled in Modal itself). `activeIdx` change auto-closes the modal.
+
+## Mobile scroll hint
+
+`sectionDone` (true when `scrollYProgress >= 0.999`) controls a fixed bottom "SCROLL" hint visible only on mobile (`md:hidden`). Stays visible through the last project — only hides after the user scrolls past the entire section.
+
+$ARGUMENTS

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -79,6 +79,18 @@ body {
 ::-webkit-scrollbar { width: 0; }
 html { scrollbar-width: none; }
 
+/* Opt-in styled scrollbar for elements that need it (e.g. project description panel) */
+.styled-scrollbar::-webkit-scrollbar       { width: 3px; }
+.styled-scrollbar::-webkit-scrollbar-track { background: transparent; }
+.styled-scrollbar::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--zone-accent) 30%, transparent);
+  border-radius: 9999px;
+}
+.styled-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--zone-accent) 55%, transparent);
+}
+.styled-scrollbar { scrollbar-width: thin; scrollbar-color: color-mix(in srgb, var(--zone-accent) 30%, transparent) transparent; }
+
 @keyframes marquee {
   from { transform: translateX(0); }
   to   { transform: translateX(-50%); }

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -22,6 +22,13 @@ export default function Modal({ isOpen, onClose, children }: ModalProps) {
     return () => window.removeEventListener("keydown", onKey);
   }, [isOpen, onClose]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = prev; };
+  }, [isOpen]);
+
   return (
     <AnimatePresence>
       {isOpen && (

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -176,7 +176,6 @@ function BkBadge({ hovered }: { hovered: boolean }) {
   );
 }
 
-// ─── Animated 2-line hamburger / X ───────────────────────────────────────────
 // ─── Animated 3-line hamburger → X ───────────────────────────────────────────
 // Open:  lines converge to center (phase 1), middle fades, outer two rotate into X (phase 2)
 // Close: X unrotates (phase 1), middle reappears, outer two spread back out (phase 2)

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from "react";
 import { useScrollLock } from "@/hooks/useScrollLock";
 import { useHudVisible } from "@/hooks/useHudVisible";
-import { HiMenu, HiX } from "react-icons/hi";
 import { motion, AnimatePresence, useScroll, useTransform, useMotionValueEvent } from "framer-motion";
 import { socialLinks } from "@/data/social";
 
@@ -177,6 +176,50 @@ function BkBadge({ hovered }: { hovered: boolean }) {
   );
 }
 
+// ─── Animated 2-line hamburger / X ───────────────────────────────────────────
+// ─── Animated 3-line hamburger → X ───────────────────────────────────────────
+// Open:  lines converge to center (phase 1), middle fades, outer two rotate into X (phase 2)
+// Close: X unrotates (phase 1), middle reappears, outer two spread back out (phase 2)
+function MenuIcon({ isOpen }: { isOpen: boolean }) {
+  const base: React.CSSProperties = {
+    position: "absolute", left: 0, height: 1.5,
+    backgroundColor: "white", borderRadius: 1, transformOrigin: "center",
+  };
+  // Container: 22×18px. Lines have staggered widths in hamburger state.
+  // All equalize to full width as they converge, then rotate into X.
+  return (
+    <div style={{ position: "relative", width: 22, height: 18 }}>
+      {/* Top line — grows then converges + rotates CW */}
+      <motion.span
+        style={{ ...base, top: 0 }}
+        animate={isOpen ? { width: [22, 28, 22], y: 8.25, rotate: 45 } : { width: 22, y: 0, rotate: 0 }}
+        transition={isOpen
+          ? { width: { duration: 0.48, times: [0, 0.35, 1], ease: "easeIn" }, y: { delay: 0.08, duration: 0.18, ease: "easeIn" }, rotate: { delay: 0.24, duration: 0.2, ease: [0.34, 1.56, 0.64, 1] } }
+          : { rotate: { duration: 0.14, ease: "easeIn" }, y: { delay: 0.12, duration: 0.22, ease: "easeOut" }, width: { delay: 0.28, duration: 0.18 } }
+        }
+      />
+      {/* Middle line — grows then fades as lines converge */}
+      <motion.span
+        style={{ ...base, top: 8.25 }}
+        animate={isOpen ? { width: [15, 28, 22], opacity: 0, scaleX: 0.2 } : { width: 15, opacity: 1, scaleX: 1 }}
+        transition={isOpen
+          ? { width: { duration: 0.48, times: [0, 0.35, 1], ease: "easeIn" }, opacity: { delay: 0.1, duration: 0.14, ease: "easeIn" }, scaleX: { delay: 0.1, duration: 0.14 } }
+          : { delay: 0.3, duration: 0.18, ease: "easeOut" }
+        }
+      />
+      {/* Bottom line — grows then converges + rotates CCW */}
+      <motion.span
+        style={{ ...base, bottom: 0 }}
+        animate={isOpen ? { width: [11, 28, 22], y: -8.25, rotate: -45 } : { width: 11, y: 0, rotate: 0 }}
+        transition={isOpen
+          ? { width: { duration: 0.48, times: [0, 0.35, 1], ease: "easeIn" }, y: { delay: 0.08, duration: 0.18, ease: "easeIn" }, rotate: { delay: 0.24, duration: 0.2, ease: [0.34, 1.56, 0.64, 1] } }
+          : { rotate: { duration: 0.14, ease: "easeIn" }, y: { delay: 0.12, duration: 0.22, ease: "easeOut" }, width: { delay: 0.28, duration: 0.18 } }
+        }
+      />
+    </div>
+  );
+}
+
 export default function NavBar() {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [active, setActive]         = useState("home");
@@ -188,11 +231,13 @@ export default function NavBar() {
 
   const handleMobileNavClick = (href: string) => {
     setSelectedHref(href);
+    // Let scan line + highlight play, then start closing (icon reverts simultaneously)
+    setTimeout(() => setMobileOpen(false), 320);
+    // Scroll after the curtain has mostly closed
     setTimeout(() => {
       scrollTo(href);
-      setMobileOpen(false);
       setSelectedHref(null);
-    }, 380);
+    }, 700);
   };
 
   // Live depth — same transform as DepthGauge
@@ -277,97 +322,106 @@ export default function NavBar() {
             onClick={() => setMobileOpen((o) => !o)}
             aria-label="Toggle menu"
           >
-            <AnimatePresence mode="wait" initial={false}>
-              {mobileOpen ? (
-                <motion.span key="close" initial={{ rotate: -90, opacity: 0 }} animate={{ rotate: 0, opacity: 1 }} exit={{ rotate: 90, opacity: 0 }} transition={{ duration: 0.18 }} className="block">
-                  <HiX size={24} />
-                </motion.span>
-              ) : (
-                <motion.span key="open" initial={{ rotate: 90, opacity: 0 }} animate={{ rotate: 0, opacity: 1 }} exit={{ rotate: -90, opacity: 0 }} transition={{ duration: 0.18 }} className="block">
-                  <HiMenu size={24} />
-                </motion.span>
-              )}
-            </AnimatePresence>
+            <MenuIcon isOpen={mobileOpen} />
           </button>
         </div>
       </motion.nav>
 
-      {/* Mobile drawer — unchanged functionality, updated accent colors */}
+      {/* ── Mobile fullscreen menu ── */}
       <AnimatePresence>
         {mobileOpen && (
-          <>
-            <motion.div key="backdrop" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.25 }} className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm md:hidden" onClick={() => setMobileOpen(false)} />
-            <motion.div key="drawer" initial={{ x: "100%" }} animate={{ x: 0 }} exit={{ x: "100%" }} transition={{ type: "spring", stiffness: 320, damping: 32 }} className="fixed top-0 right-0 bottom-0 z-50 w-72 bg-[rgba(2,8,23,0.97)] backdrop-blur-xl border-l flex flex-col md:hidden" style={{ borderColor: "color-mix(in srgb, var(--zone-accent) 25%, transparent)" }}>
+          <motion.div
+            key="mobile-menu"
+            className="fixed inset-0 z-40 flex flex-col md:hidden"
+            style={{ background: "linear-gradient(160deg, #020817 0%, #010c1a 100%)", cursor: "default" }}
+            initial={{ clipPath: "inset(0 0 100% 0)" }}
+            animate={{ clipPath: "inset(0 0 0% 0)" }}
+            exit={{ clipPath: "inset(0 0 100% 0)" }}
+            transition={{ duration: 0.55, ease: [0.16, 1, 0.3, 1] }}
+          >
+            {/* Align with navbar */}
+            <div className="h-16 shrink-0" />
+            <div className="h-px shrink-0 opacity-20" style={{ backgroundColor: "var(--zone-accent)" }} />
 
-              {/* Header */}
-              <div className="h-16 flex items-center justify-between px-5 shrink-0 border-b" style={{ borderColor: "color-mix(in srgb, var(--zone-accent) 15%, transparent)" }}>
-                <span className="text-[9px] font-mono tracking-[0.25em] uppercase opacity-50" style={{ color: "var(--zone-accent)" }}>
-                  {zoneName(depth)}
-                </span>
-                <button onClick={() => setMobileOpen(false)} className="text-white/40 hover:text-white transition-colors cursor-pointer" aria-label="Close menu">
-                  <HiX size={20} />
-                </button>
-              </div>
-
-              {/* Links — scrollable so nothing clips on short screens */}
-              <div className="flex flex-col px-4 pt-5 gap-0.5 overflow-y-auto flex-1">
-                {navLinks.map(({ href, label }, i) => {
-                  const isActive   = active === href.replace("#", "");
-                  const isSelected = selectedHref === href;
-                  const isDimmed   = selectedHref !== null && !isSelected;
-                  return (
-                    <motion.div key={href} initial={{ opacity: 0, x: 20 }} animate={{ opacity: 1, x: 0 }} transition={{ delay: 0.06 + i * 0.05, duration: 0.22 }}>
-                      {/* Selection dim wrapper */}
-                      <motion.div animate={{ opacity: isDimmed ? 0.2 : 1 }} transition={{ duration: 0.15 }}>
-                        <button
-                          onClick={() => handleMobileNavClick(href)}
-                          className="w-full text-left flex items-center gap-3 px-3 py-3.5 text-base font-medium cursor-pointer border-b relative overflow-hidden"
-                          style={{
-                            borderColor: "rgba(255,255,255,0.06)",
-                            color: isSelected || isActive ? "var(--zone-accent)" : "rgba(255,255,255,0.55)",
-                          }}
-                        >
-                          {/* Scan line on select */}
-                          <AnimatePresence>
-                            {isSelected && (
-                              <motion.span
-                                key="scan"
-                                className="absolute top-0 bottom-0 w-24 pointer-events-none"
-                                style={{ background: "linear-gradient(90deg, transparent, var(--zone-accent) 50%, transparent)", opacity: 0.28 }}
-                                initial={{ left: "-6rem" }}
-                                animate={{ left: "110%" }}
-                                transition={{ duration: 0.35, ease: "easeOut" }}
-                              />
-                            )}
-                          </AnimatePresence>
-
-                          <span
-                            className="text-[10px] font-mono w-5 shrink-0 transition-opacity"
-                            style={{ color: "var(--zone-accent)", opacity: isSelected ? 1 : 0.4 }}
-                          >
-                            {String(i + 1).padStart(2, "0")}
-                          </span>
-                          {label}
-                          {(isActive || isSelected) && (
-                            <span className="ml-auto w-1 h-4 rounded-full shrink-0" style={{ backgroundColor: "var(--zone-accent)" }} />
+            {/* Nav links — large typographic list */}
+            <div className="flex-1 flex flex-col justify-center px-8 gap-1">
+              {navLinks.map(({ href, label }, i) => {
+                const isActive   = active === href.replace("#", "");
+                const isSelected = selectedHref === href;
+                const isDimmed   = selectedHref !== null && !isSelected;
+                return (
+                  <motion.div
+                    key={href}
+                    initial={{ opacity: 0, y: 28 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: 0.2 + i * 0.07, duration: 0.45, ease: [0.16, 1, 0.3, 1] }}
+                  >
+                    <motion.div animate={{ opacity: isDimmed ? 0.1 : 1 }} transition={{ duration: 0.18 }}>
+                      <button
+                        onClick={() => handleMobileNavClick(href)}
+                        className="w-full text-left flex items-center gap-5 py-3 relative overflow-hidden cursor-pointer"
+                      >
+                        {/* Scan line sweep on select */}
+                        <AnimatePresence>
+                          {isSelected && (
+                            <motion.span
+                              key="scan"
+                              className="absolute inset-0 pointer-events-none"
+                              style={{ background: "linear-gradient(90deg, transparent 0%, color-mix(in srgb, var(--zone-accent) 22%, transparent) 50%, transparent 100%)" }}
+                              initial={{ x: "-100%" }}
+                              animate={{ x: "100%" }}
+                              transition={{ duration: 0.38, ease: "easeOut" }}
+                            />
                           )}
-                        </button>
-                      </motion.div>
-                    </motion.div>
-                  );
-                })}
-              </div>
+                        </AnimatePresence>
 
-              {/* Social links */}
-              <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.35 }} className="px-5 py-5 border-t flex gap-5 shrink-0" style={{ borderColor: "color-mix(in srgb, var(--zone-accent) 15%, transparent)" }}>
+                        <span
+                          className="font-mono text-[11px] tabular-nums shrink-0 w-5"
+                          style={{ color: "var(--zone-accent)", opacity: isSelected || isActive ? 0.9 : 0.3 }}
+                        >
+                          {String(i + 1).padStart(2, "0")}
+                        </span>
+
+                        <span
+                          className="text-5xl font-bold tracking-tight leading-none transition-colors duration-150"
+                          style={{ color: isSelected || isActive ? "var(--zone-accent)" : "rgba(255,255,255,0.88)" }}
+                        >
+                          {label}
+                        </span>
+
+                        {isActive && (
+                          <motion.span
+                            layoutId="mobile-active-pip"
+                            className="ml-auto w-1.5 h-1.5 rounded-full shrink-0"
+                            style={{ backgroundColor: "var(--zone-accent)" }}
+                          />
+                        )}
+                      </button>
+                    </motion.div>
+                  </motion.div>
+                );
+              })}
+            </div>
+
+            {/* Footer — zone name + social */}
+            <motion.div
+              className="px-8 pb-10 flex items-center justify-between shrink-0"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 0.55, duration: 0.3 }}
+            >
+              <span className="text-[10px] font-mono tracking-[0.25em] uppercase opacity-35" style={{ color: "var(--zone-accent)" }}>
+                {zoneName(depth)}
+              </span>
+              <div className="flex gap-5">
                 {socialLinks.map(({ Icon, href, label }) => (
-                  <a key={label} href={href} target={href.startsWith("mailto") ? undefined : "_blank"} rel="noopener noreferrer" className="text-white/30 hover:text-white transition-colors" aria-label={label}>
+                  <a key={label} href={href} target={href.startsWith("mailto") ? undefined : "_blank"} rel="noopener noreferrer" className="text-white/25 hover:text-white transition-colors" aria-label={label}>
                     <Icon size={18} />
                   </a>
                 ))}
-              </motion.div>
+              </div>
             </motion.div>
-          </>
+          </motion.div>
         )}
       </AnimatePresence>
     </>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -342,8 +342,11 @@ export default function NavBar() {
             <div className="h-16 shrink-0" />
             <div className="h-px shrink-0 opacity-20" style={{ backgroundColor: "var(--zone-accent)" }} />
 
-            {/* Nav links — large typographic list */}
-            <div className="flex-1 flex flex-col justify-center px-8 gap-1">
+            {/* Nav links — large typographic list.
+                Outer div scrolls; inner div centers when content fits,
+                scrolls without clipping when viewport is short. */}
+            <div className="flex-1 min-h-0 overflow-y-auto px-8 py-4">
+              <div className="flex flex-col justify-center min-h-full gap-1">
               {navLinks.map(({ href, label }, i) => {
                 const isActive   = active === href.replace("#", "");
                 const isSelected = selectedHref === href;
@@ -400,6 +403,7 @@ export default function NavBar() {
                   </motion.div>
                 );
               })}
+              </div>
             </div>
 
             {/* Footer — zone name + social */}

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -389,16 +389,18 @@ export default function ProjectsGallery() {
                       </div>
                     ) : (
                       /* Compact non-active row */
-                      <div
+                      <button
+                        type="button"
                         style={{ height: ITEM_H, cursor: "pointer" }}
                         onClick={() => scrollToProject(i)}
-                        className="flex items-center gap-2.5 select-none"
+                        className="flex w-full items-center gap-2.5 select-none text-left"
+                        aria-label={`Go to project ${i + 1}: ${p.title}`}
                       >
                         <span className="font-mono text-[10px] tabular-nums shrink-0" style={{ color: "rgba(255,255,255,0.35)" }}>
                           {String(i + 1).padStart(2, "0")}
                         </span>
                         <span className="text-sm leading-tight truncate text-white/60 font-medium">{p.title}</span>
-                      </div>
+                      </button>
                     )}
                   </motion.div>
                 );

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -236,13 +236,15 @@ export default function ProjectsGallery() {
   const springProgress = useSpring(scrollYProgress, { stiffness: 100, damping: 30 });
 
   const [sectionDone, setSectionDone] = useState(false);
+  // Refs used by the scroll listener and resize handler — declared first to avoid
+  // forward-reference confusion even though closures capture them by identity.
+  const activeIdxRef = useRef(0);
+  const isResizing   = useRef(false);
 
-  // Single listener drives both active-project tracking and section-done flag.
-  // rawIdx equivalent: scrollYProgress * (N - 0.0001), mapping [0,1] → [0,N).
-  const isResizing = useRef(false);
-
+  // Single listener: tracks active project and section-done flag.
+  // Maps scrollYProgress [0,1] → [0,N) via Math.floor(v * (N - 0.0001)).
   useMotionValueEvent(scrollYProgress, "change", (v) => {
-    if (isResizing.current) return; // ignore scroll position changes caused by resize
+    if (isResizing.current) return; // freeze during resize — handler restores position
     setSectionDone(v >= 0.999);
     const next = Math.floor(v * (N - 0.0001));
     activeIdxRef.current = next;
@@ -260,10 +262,7 @@ export default function ProjectsGallery() {
   const handlePrev = () => setImageIdx((i) => (i === 0 ? project.images.length - 1 : i - 1));
   const handleNext = () => setImageIdx((i) => (i === project.images.length - 1 ? 0 : i + 1));
 
-  // Scroll to the midpoint of project `idx`'s scroll range.
-  // Targeting the exact boundary (idx/N) lands rawIdx just below idx due to the
-  // [0, N-0.0001] transform, so Math.floor gives idx-1. Midpoint is always safe.
-  // Target rawIdx = idx + 0.4 — the center of each project's full-opacity zone [i, i+0.8].
+  // Scroll to idx + 0.4 within its scroll band (midpoint avoids boundary rounding issues).
   const scrollToProject = (idx: number) => {
     const el = sectionRef.current;
     if (!el) return;
@@ -275,7 +274,6 @@ export default function ProjectsGallery() {
 
   // On resize, scrollYProgress recalculates (viewport height changed) which can shift
   // activeIdx. Capture the active project at resize start and restore it once settled.
-  const activeIdxRef = useRef(0);
   useEffect(() => {
     const resizeTarget = { idx: -1 };
     let timeout: ReturnType<typeof setTimeout>;

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -9,7 +9,6 @@ import {
   motion,
   AnimatePresence,
   useScroll,
-  useTransform,
   useSpring,
   useMotionValue,
   useMotionTemplate,
@@ -20,8 +19,8 @@ import Modal from "./Modal";
 
 const N = projectsData.length;
 const NAV_H = 64;
-const ITEM_H = 40; // px — height of each rolling list row (title only, no description)
-const VISIBLE = 5; // rows visible in the rolling list
+const ITEM_H = 40; // px — height of each compact (non-active) list row
+const PILL_CLS = "text-xs px-2.5 py-1 bg-blue-500/15 text-blue-300 rounded-full border border-blue-500/20";
 
 // ── Corner bracket decorations ─────────────────────────────────────────────────
 function ScreenBrackets() {
@@ -220,42 +219,43 @@ export default function ProjectsGallery() {
     offset: ["start start", "end end"],
   });
 
-  const rawIdx = useTransform(scrollYProgress, [0, 1], [0, N - 0.0001]);
+  const springProgress = useSpring(scrollYProgress, { stiffness: 100, damping: 30 });
 
-  useMotionValueEvent(rawIdx, "change", (v) => {
-    const next = Math.floor(v);
+  const [sectionDone, setSectionDone] = useState(false);
+
+  // Single listener drives both active-project tracking and section-done flag.
+  // rawIdx equivalent: scrollYProgress * (N - 0.0001), mapping [0,1] → [0,N).
+  useMotionValueEvent(scrollYProgress, "change", (v) => {
+    setSectionDone(v >= 0.999);
+    const next = Math.floor(v * (N - 0.0001));
     setActiveIdx((prev) => {
       if (prev === next) return prev;
-      setImageIdx(0); // reset image carousel on project change
+      setImageIdx(0);
       return next;
     });
   });
 
-  const springProgress = useSpring(scrollYProgress, { stiffness: 100, damping: 30 });
-
-  // Close modal on project change
   useEffect(() => { setDescModal(false); }, [activeIdx]);
 
-
   const project = projectsData[activeIdx];
-  const images = project.images;
 
-  const handlePrev = () => setImageIdx((i) => (i === 0 ? images.length - 1 : i - 1));
-  const handleNext = () => setImageIdx((i) => (i === images.length - 1 ? 0 : i + 1));
+  const handlePrev = () => setImageIdx((i) => (i === 0 ? project.images.length - 1 : i - 1));
+  const handleNext = () => setImageIdx((i) => (i === project.images.length - 1 ? 0 : i + 1));
 
   // Scroll to the midpoint of project `idx`'s scroll range.
   // Targeting the exact boundary (idx/N) lands rawIdx just below idx due to the
   // [0, N-0.0001] transform, so Math.floor gives idx-1. Midpoint is always safe.
+  // Target rawIdx = idx + 0.4 — the center of each project's full-opacity zone [i, i+0.8].
   const scrollToProject = (idx: number) => {
     const el = sectionRef.current;
     if (!el) return;
     const top = el.getBoundingClientRect().top + window.scrollY;
     const h = el.offsetHeight;
-    const target = top + ((idx + 0.5) / N) * Math.max(h - window.innerHeight, 0);
+    const target = top + ((idx + 0.4) / N) * Math.max(h - window.innerHeight, 0);
     window.scrollTo({ top: Math.max(0, target), behavior: "smooth" });
   };
 
-  const counterStr = String(activeIdx + 1).padStart(2, "0") + " / " + String(N).padStart(2, "0");
+
 
   return (
     <div ref={sectionRef} style={{ height: `${N * 80}vh` }}>
@@ -286,85 +286,10 @@ export default function ProjectsGallery() {
           </div>
         </div>
 
-        {/* ── RIGHT: Project info + rolling list ── */}
-        <div
-          className="flex-1 flex flex-col justify-start md:justify-center px-6 md:px-8 pt-4 pb-6 md:py-10 border-t md:border-t-0 md:border-l border-white/8"
-        >
-          {/* Info block — animates on project change */}
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={project.key + "-info"}
-              initial={{ opacity: 0, y: 14 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -10 }}
-              transition={{ duration: 0.35 }}
-              className="shrink-0"
-            >
-              {/* Counter */}
-              <p className="font-mono text-xs tracking-widest mb-3" style={{ color: "var(--zone-accent)", opacity: 0.6 }}>
-                {counterStr}
-              </p>
-
-              {/* Title + links */}
-              <div className="flex items-start justify-between gap-3 mb-1">
-                <h3 className="text-white font-bold text-2xl md:text-3xl leading-tight">
-                  {project.title}
-                </h3>
-                <div className="flex gap-3 shrink-0 pt-1">
-                  {project.sourceCode && (
-                    <a href={project.sourceCode} target="_blank" rel="noopener noreferrer"
-                      className="text-white/40 hover:text-white transition-colors" aria-label="Source code">
-                      <FaGithub size={18} />
-                    </a>
-                  )}
-                  {project.deployment && (
-                    <a href={project.deployment} target="_blank" rel="noopener noreferrer"
-                      className="text-white/40 hover:text-white transition-colors" aria-label="Live site">
-                      <FaExternalLinkAlt size={15} />
-                    </a>
-                  )}
-                </div>
-              </div>
-
-              {/* Client */}
-              <p className="text-sm mb-2" style={{ color: "var(--zone-accent)" }}>
-                {project.client}
-              </p>
-
-              {/* Description */}
-              <p className="text-white/55 text-sm leading-relaxed line-clamp-2 md:line-clamp-4 mb-1">
-                {project.description}
-              </p>
-              <button
-                onClick={() => setDescModal(true)}
-                className="text-xs font-semibold mb-3 tracking-wide"
-                style={{ color: "var(--zone-accent)", cursor: "pointer" }}
-              >
-                more ↗
-              </button>
-
-              {/* Tech pills */}
-              <div className="flex flex-wrap gap-2">
-                {project.technologies.map((tech) => (
-                  <span
-                    key={tech}
-                    className="text-xs px-2.5 py-1 bg-blue-500/15 text-blue-300 rounded-full border border-blue-500/20"
-                  >
-                    {tech}
-                  </span>
-                ))}
-              </div>
-            </motion.div>
-          </AnimatePresence>
-
-          {/* Divider */}
-          <div className="h-px bg-white/8 my-4 shrink-0" />
-
-          {/* Rolling project list */}
-          <div
-            className="relative overflow-hidden shrink-0"
-            style={{ height: ITEM_H * VISIBLE }}
-          >
+        {/* ── RIGHT: Unified project list — active item expands with full info ── */}
+        <div className="flex-1 flex flex-col px-6 md:px-8 pt-4 pb-6 md:py-10 border-t md:border-t-0 md:border-l border-white/8 overflow-hidden">
+          {/* List scrolls so active item is always at the top */}
+          <div className="flex-1 min-h-0 relative overflow-hidden">
             <motion.div
               animate={{ y: -activeIdx * ITEM_H }}
               transition={{ type: "spring", stiffness: 280, damping: 38, mass: 0.8 }}
@@ -372,25 +297,70 @@ export default function ProjectsGallery() {
               {projectsData.map((p, i) => {
                 const dist = Math.abs(i - activeIdx);
                 const isActive = i === activeIdx;
-                const opacity = isActive ? 1 : dist === 1 ? 0.5 : 0.18;
+                const rowOpacity = isActive ? 1 : dist === 1 ? 0.5 : 0.18;
+                const counter = String(i + 1).padStart(2, "0") + " / " + String(N).padStart(2, "0");
+
                 return (
                   <motion.div
                     key={p.key}
-                    animate={{ opacity }}
+                    animate={{ opacity: rowOpacity }}
                     transition={{ duration: 0.3 }}
-                    style={{ height: ITEM_H, cursor: "pointer" }}
-                    onClick={() => scrollToProject(i)}
-                    className="flex items-center gap-2.5 select-none"
                   >
-                    <span
-                      className="font-mono text-[10px] tabular-nums shrink-0"
-                      style={{ color: isActive ? "var(--zone-accent)" : "rgba(255,255,255,0.35)" }}
-                    >
-                      {String(i + 1).padStart(2, "0")}
-                    </span>
-                    <span className={`text-sm leading-tight truncate ${isActive ? "text-white font-semibold" : "text-white/60 font-medium"}`}>
-                      {p.title}
-                    </span>
+                    {isActive ? (
+                      /* Expanded active item */
+                      <div className="pb-5">
+                        <p className="font-mono text-xs tracking-widest mb-2" style={{ color: "var(--zone-accent)", opacity: 0.6 }}>
+                          {counter}
+                        </p>
+                        <div className="flex items-start justify-between gap-3 mb-1">
+                          <h3 className="text-white font-bold text-2xl md:text-3xl leading-tight">{p.title}</h3>
+                          <div className="flex gap-3 shrink-0 pt-1">
+                            {p.sourceCode && (
+                              <a href={p.sourceCode} target="_blank" rel="noopener noreferrer"
+                                className="text-white/40 hover:text-white transition-colors" aria-label="Source code">
+                                <FaGithub size={18} />
+                              </a>
+                            )}
+                            {p.deployment && (
+                              <a href={p.deployment} target="_blank" rel="noopener noreferrer"
+                                className="text-white/40 hover:text-white transition-colors" aria-label="Live site">
+                                <FaExternalLinkAlt size={15} />
+                              </a>
+                            )}
+                          </div>
+                        </div>
+                        <p className="text-sm mb-3" style={{ color: "var(--zone-accent)" }}>{p.client}</p>
+                        <div className="flex flex-wrap gap-2 mb-3">
+                          {p.technologies.slice(0, 3).map((tech) => (
+                            <span key={tech} className={PILL_CLS}>{tech}</span>
+                          ))}
+                          {p.technologies.length > 3 && (
+                            <span className="text-xs px-2.5 py-1 bg-white/5 text-white/40 rounded-full border border-white/10">
+                              +{p.technologies.length - 3}
+                            </span>
+                          )}
+                        </div>
+                        <button
+                          onClick={() => setDescModal(true)}
+                          className="text-xs font-semibold tracking-wide"
+                          style={{ color: "var(--zone-accent)", cursor: "pointer" }}
+                        >
+                          Read more ↗
+                        </button>
+                      </div>
+                    ) : (
+                      /* Compact non-active row */
+                      <div
+                        style={{ height: ITEM_H, cursor: "pointer" }}
+                        onClick={() => scrollToProject(i)}
+                        className="flex items-center gap-2.5 select-none"
+                      >
+                        <span className="font-mono text-[10px] tabular-nums shrink-0" style={{ color: "rgba(255,255,255,0.35)" }}>
+                          {String(i + 1).padStart(2, "0")}
+                        </span>
+                        <span className="text-sm leading-tight truncate text-white/60 font-medium">{p.title}</span>
+                      </div>
+                    )}
                   </motion.div>
                 );
               })}
@@ -401,7 +371,7 @@ export default function ProjectsGallery() {
 
       {/* ── Mobile scroll hint — visible on first project until user scrolls ── */}
       <AnimatePresence>
-        {activeIdx < N - 1 && (
+        {!sectionDone && (
           <motion.div
             className="fixed bottom-6 left-1/2 -translate-x-1/2 flex flex-col items-center gap-1 z-20 md:hidden pointer-events-none"
             initial={{ opacity: 0, y: 6 }}
@@ -425,14 +395,13 @@ export default function ProjectsGallery() {
       {/* ── Description modal ── */}
       <Modal isOpen={descModal} onClose={() => setDescModal(false)}>
         <div
-          className="w-full max-w-md max-h-[70vh] flex flex-col rounded-xl overflow-hidden"
+          className="w-full max-w-sm max-h-[70vh] flex flex-col rounded-xl overflow-hidden"
           style={{
             background: "color-mix(in srgb, var(--zone-accent) 6%, #020c18)",
             border: "1px solid color-mix(in srgb, var(--zone-accent) 25%, transparent)",
             boxShadow: "0 24px 64px rgba(0,0,0,0.7)",
           }}
         >
-          {/* Header */}
           <div
             className="flex items-center justify-between px-5 py-3 shrink-0"
             style={{ borderBottom: "1px solid color-mix(in srgb, var(--zone-accent) 18%, transparent)" }}
@@ -447,18 +416,11 @@ export default function ProjectsGallery() {
               ✕
             </button>
           </div>
-
-          {/* Scrollable body */}
           <div className="overflow-y-auto px-5 py-4 space-y-4">
             <p className="text-white/70 text-sm leading-relaxed">{project.description}</p>
             <div className="flex flex-wrap gap-2">
               {project.technologies.map((tech) => (
-                <span
-                  key={tech}
-                  className="text-xs px-2.5 py-1 bg-blue-500/15 text-blue-300 rounded-full border border-blue-500/20"
-                >
-                  {tech}
-                </span>
+                <span key={tech} className={PILL_CLS}>{tech}</span>
               ))}
             </div>
           </div>

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -68,10 +68,14 @@ function HudScreen({ project, imageIdx, onPrev, onNext, onImageChange }: HudScre
   const springY = useSpring(tiltY, { stiffness: 280, damping: 22 });
   const tiltTransform = useMotionTemplate`perspective(900px) rotateY(${springY}deg) rotateX(${springX}deg) translateY(-6px)`;
 
+  const [isDesktop, setIsDesktop] = useState(false);
+
   // Track cursor anywhere on the viewport and tilt the screen toward it
   useEffect(() => {
-    const isDesktop = window.matchMedia("(min-width: 768px)").matches;
-    if (!isDesktop) return;
+    const mq = window.matchMedia("(min-width: 768px)");
+    setIsDesktop(mq.matches);
+
+    if (!mq.matches) return;
 
     tiltX.set(TILT_BASE.x);
     tiltY.set(TILT_BASE.y);
@@ -83,14 +87,24 @@ function HudScreen({ project, imageIdx, onPrev, onNext, onImageChange }: HudScre
       tiltX.set(TILT_BASE.x - ny * 4);
     };
 
+    const onMqChange = (e: MediaQueryListEvent) => {
+      setIsDesktop(e.matches);
+      if (!e.matches) { tiltX.set(0); tiltY.set(0); }
+      else { tiltX.set(TILT_BASE.x); tiltY.set(TILT_BASE.y); }
+    };
+
     window.addEventListener("mousemove", onMove, { passive: true });
-    return () => window.removeEventListener("mousemove", onMove);
+    mq.addEventListener("change", onMqChange);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      mq.removeEventListener("change", onMqChange);
+    };
   }, [tiltX, tiltY]);
 
   return (
     <motion.div
       className="relative mx-auto w-full"
-      style={{ maxWidth: 640, cursor: "default", transform: tiltTransform }}
+      style={{ maxWidth: 640, cursor: "default", transform: isDesktop ? tiltTransform : undefined }}
     >
       {/* Screen frame */}
       <div
@@ -225,9 +239,13 @@ export default function ProjectsGallery() {
 
   // Single listener drives both active-project tracking and section-done flag.
   // rawIdx equivalent: scrollYProgress * (N - 0.0001), mapping [0,1] → [0,N).
+  const isResizing = useRef(false);
+
   useMotionValueEvent(scrollYProgress, "change", (v) => {
+    if (isResizing.current) return; // ignore scroll position changes caused by resize
     setSectionDone(v >= 0.999);
     const next = Math.floor(v * (N - 0.0001));
+    activeIdxRef.current = next;
     setActiveIdx((prev) => {
       if (prev === next) return prev;
       setImageIdx(0);
@@ -255,6 +273,31 @@ export default function ProjectsGallery() {
     window.scrollTo({ top: Math.max(0, target), behavior: "smooth" });
   };
 
+  // On resize, scrollYProgress recalculates (viewport height changed) which can shift
+  // activeIdx. Capture the active project at resize start and restore it once settled.
+  const activeIdxRef = useRef(0);
+  useEffect(() => {
+    const resizeTarget = { idx: -1 };
+    let timeout: ReturnType<typeof setTimeout>;
+    const onResize = () => {
+      if (resizeTarget.idx === -1) resizeTarget.idx = activeIdxRef.current;
+      isResizing.current = true; // freeze activeIdx while viewport is changing
+      clearTimeout(timeout);
+      timeout = setTimeout(() => {
+        const el = sectionRef.current;
+        if (el) {
+          const top = el.getBoundingClientRect().top + window.scrollY;
+          const h = el.offsetHeight;
+          const target = top + ((resizeTarget.idx + 0.4) / N) * Math.max(h - window.innerHeight, 0);
+          window.scrollTo({ top: Math.max(0, target), behavior: "instant" });
+        }
+        resizeTarget.idx = -1;
+        isResizing.current = false; // resume normal scroll tracking
+      }, 200);
+    };
+    window.addEventListener("resize", onResize);
+    return () => { window.removeEventListener("resize", onResize); clearTimeout(timeout); };
+  }, []); // empty deps — only refs (sectionRef, activeIdxRef) and constant N
 
 
   return (

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -274,7 +274,7 @@ export default function ProjectsGallery() {
 
         {/* ── LEFT: HUD Screen ── */}
         {/* max-h-[52%] on mobile caps the HUD so the info panel always gets the rest of the viewport */}
-        <div className="md:w-[55%] max-h-[52%] md:max-h-none flex items-center justify-center p-4 md:p-10 md:pl-8 shrink-0 overflow-hidden">
+        <div className="md:w-[55%] max-h-[52%] md:max-h-none flex items-start md:items-center justify-center p-4 md:p-10 md:pl-8 shrink-0 overflow-hidden">
           <div className="w-full">
             <HudScreen
               project={project}
@@ -398,6 +398,29 @@ export default function ProjectsGallery() {
           </div>
         </div>
       </div>
+
+      {/* ── Mobile scroll hint — visible on first project until user scrolls ── */}
+      <AnimatePresence>
+        {activeIdx < N - 1 && (
+          <motion.div
+            className="fixed bottom-6 left-1/2 -translate-x-1/2 flex flex-col items-center gap-1 z-20 md:hidden pointer-events-none"
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: [0, -5, 0] }}
+            exit={{ opacity: 0, y: 6 }}
+            transition={{ duration: 0.4, delay: 0.6, y: { duration: 2, repeat: Infinity, ease: "easeInOut", delay: 0.6 } }}
+          >
+            <span className="text-[9px] font-mono tracking-[0.2em] uppercase" style={{ color: "var(--zone-accent)", opacity: 0.5 }}>
+              scroll
+            </span>
+            <motion.span
+              className="block w-px h-5"
+              style={{ background: "linear-gradient(to bottom, var(--zone-accent), transparent)" }}
+              animate={{ scaleY: [1, 0.4, 1], opacity: [0.5, 1, 0.5] }}
+              transition={{ duration: 1.4, repeat: Infinity, ease: "easeInOut" }}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* ── Description modal ── */}
       <Modal isOpen={descModal} onClose={() => setDescModal(false)}>

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -68,30 +68,28 @@ function HudScreen({ project, imageIdx, onPrev, onNext, onImageChange }: HudScre
   const springY = useSpring(tiltY, { stiffness: 280, damping: 22 });
   const tiltTransform = useMotionTemplate`perspective(900px) rotateY(${springY}deg) rotateX(${springX}deg) translateY(-6px)`;
 
-  const [isDesktop, setIsDesktop] = useState(false);
-
-  // Track cursor anywhere on the viewport and tilt the screen toward it
+  // Track cursor anywhere on the viewport and tilt the screen toward it.
+  // Always keep tiltTransform wired to the motion.div — MotionValues must be
+  // subscribed from the first render. Straightening on mobile is done by zeroing
+  // the values, not by removing the style prop.
   useEffect(() => {
     const mq = window.matchMedia("(min-width: 768px)");
-    setIsDesktop(mq.matches);
 
-    if (!mq.matches) return;
-
-    tiltX.set(TILT_BASE.x);
-    tiltY.set(TILT_BASE.y);
+    const applyBase = (desktop: boolean) => {
+      tiltX.set(desktop ? TILT_BASE.x : 0);
+      tiltY.set(desktop ? TILT_BASE.y : 0);
+    };
+    applyBase(mq.matches);
 
     const onMove = (e: MouseEvent) => {
-      const nx = (e.clientX / window.innerWidth) * 2 - 1;   // -1 … 1
+      if (!mq.matches) return;
+      const nx = (e.clientX / window.innerWidth) * 2 - 1;
       const ny = (e.clientY / window.innerHeight) * 2 - 1;
       tiltY.set(TILT_BASE.y + nx * 5);
       tiltX.set(TILT_BASE.x - ny * 4);
     };
 
-    const onMqChange = (e: MediaQueryListEvent) => {
-      setIsDesktop(e.matches);
-      if (!e.matches) { tiltX.set(0); tiltY.set(0); }
-      else { tiltX.set(TILT_BASE.x); tiltY.set(TILT_BASE.y); }
-    };
+    const onMqChange = (e: MediaQueryListEvent) => applyBase(e.matches);
 
     window.addEventListener("mousemove", onMove, { passive: true });
     mq.addEventListener("change", onMqChange);
@@ -104,7 +102,7 @@ function HudScreen({ project, imageIdx, onPrev, onNext, onImageChange }: HudScre
   return (
     <motion.div
       className="relative mx-auto w-full"
-      style={{ maxWidth: 640, cursor: "default", transform: isDesktop ? tiltTransform : undefined }}
+      style={{ maxWidth: 640, cursor: "default", transform: tiltTransform }}
     >
       {/* Screen frame */}
       <div


### PR DESCRIPTION
## Summary

- **Mobile nav:** replaced slide-out drawer with fullscreen takeover overlay; custom animated 3-line hamburger → X icon with staggered converge/rotate sequence; large typographic link list with scan-line selection effect; scrollable on short viewports so all links are always reachable
- **Projects panel:** unified expand-in-place list — active project expands inline with title, client, tech pills, and a read-more modal; non-active rows are compact and clickable; replaces the previous split title/info layout
- **Polish & fixes:** desktop HUD screen tilt + mouse tracking restored; tilt zeroes on mobile/vertical layout; resize no longer flickers the active project; HUD top clipping fixed on mobile; scroll hint stays visible through the last project
- **Accessibility:** compact project rows are `<button>` elements with `aria-label` instead of click-handled `div`s
- **Claude skills:** added `/nav`, `/projects-gallery`, and `/ocean-design-system` command files under `.claude/commands/` to carry forward component context across sessions

## Test plan

- [ ] Mobile nav opens/closes with animated hamburger; links scroll to correct sections
- [ ] Mobile nav scrolls on a short viewport (all 5 links reachable)
- [ ] Projects: scrolling advances active project; clicking compact rows jumps to that project
- [ ] Projects: resizing window does not change the active project
- [ ] Desktop: HUD screen tilts toward cursor and responds to mouse movement
- [ ] Mobile/vertical: HUD screen is flat (no 3D tilt)
- [ ] Read more modal opens with full description; body scroll locked while open
- [ ] Keyboard navigation works on compact project rows (tab + enter)