### PR TITLE
Copy updates, button refactor, scroll/resize fixes

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -7,6 +7,7 @@ import DepthSection from "@/components/ocean/DepthSection";
 import DepthLabel from "@/components/ocean/DepthLabel";
 import { bioData } from "@/data/bio";
 import ResumeButton from "@/components/ResumeButton";
+import Button from "@/components/Button";
 import SectionHeading from "@/components/SectionHeading";
 
 const EASE = [0.25, 0.1, 0.25, 1] as const;
@@ -158,13 +159,9 @@ export default function AboutSection() {
           <FadeUp delay={0.44}>
             <div className="flex flex-wrap gap-3 pt-2">
               <ResumeButton />
-              <motion.a
-                href="mailto:billyhkaufman@gmail.com"
-                className="clip-bl px-5 py-2.5 bg-white/10 hover:bg-white/20 text-white font-semibold border border-white/20 transition-colors text-sm"
-                whileTap={{ scale: 0.94 }}
-              >
+              <Button variant="secondary" href="mailto:billyhkaufman@gmail.com">
                 Hire Me
-              </motion.a>
+              </Button>
             </div>
           </FadeUp>
         </div>

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -158,9 +158,13 @@ export default function AboutSection() {
           <FadeUp delay={0.44}>
             <div className="flex flex-wrap gap-3 pt-2">
               <ResumeButton />
-              <a href="mailto:billyhkaufman@gmail.com" className="clip-bl px-5 py-2.5 bg-white/10 hover:bg-white/20 text-white font-semibold border border-white/20 transition-colors text-sm">
+              <motion.a
+                href="mailto:billyhkaufman@gmail.com"
+                className="clip-bl px-5 py-2.5 bg-white/10 hover:bg-white/20 text-white font-semibold border border-white/20 transition-colors text-sm"
+                whileTap={{ scale: 0.94 }}
+              >
                 Hire Me
-              </a>
+              </motion.a>
             </div>
           </FadeUp>
         </div>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+type Variant = "primary" | "secondary" | "cta-lg";
+
+const VARIANT_CLS: Record<Variant, string> = {
+  primary:   "btn-cta clip-tr-bl px-5 py-2.5 font-semibold text-sm cursor-pointer",
+  secondary: "clip-bl px-5 py-2.5 bg-white/8 hover:bg-white/15 text-white font-semibold border border-white/15 transition-colors text-sm",
+  "cta-lg":  "btn-cta clip-tr-lg px-8 py-4 font-bold text-lg",
+};
+
+const VARIANT_TAP: Record<Variant, { scale: number }> = {
+  primary:   { scale: 0.94 },
+  secondary: { scale: 0.94 },
+  "cta-lg":  { scale: 0.97 },
+};
+
+interface Props {
+  variant?: Variant;
+  href?: string;
+  onClick?: (e: React.MouseEvent) => void;
+  target?: string;
+  rel?: string;
+  download?: string;
+  type?: "button" | "submit";
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Button({
+  variant = "secondary",
+  href,
+  onClick,
+  target,
+  rel,
+  download,
+  type = "button",
+  children,
+  className,
+}: Props) {
+  const cls = [VARIANT_CLS[variant], className].filter(Boolean).join(" ");
+  const tap = VARIANT_TAP[variant];
+
+  if (href) {
+    return (
+      <motion.a href={href} target={target} rel={rel} download={download} onClick={onClick} className={cls} whileTap={tap}>
+        {children}
+      </motion.a>
+    );
+  }
+  return (
+    <motion.button type={type} onClick={onClick} className={cls} whileTap={tap}>
+      {children}
+    </motion.button>
+  );
+}

--- a/src/components/ClientsMarquee.tsx
+++ b/src/components/ClientsMarquee.tsx
@@ -205,15 +205,15 @@ export default function ClientsMarquee() {
                 <p className="text-white/70 text-sm leading-relaxed text-center">
                   {openClient.description}
                 </p>
-                {openClient.domain && (
+                {openClient.url && (
                   <a
-                    href={openClient.url ?? `https://${openClient.domain}`}
+                    href={openClient.url}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-xs transition-colors"
                     style={{ color: openClient.accentColor }}
                   >
-                    {openClient.domain} ↗
+                    {new URL(openClient.url).hostname.replace(/^www\./, "")} ↗
                   </a>
                 )}
                 <button

--- a/src/components/ContactFooter.tsx
+++ b/src/components/ContactFooter.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import DepthLabel from "@/components/ocean/DepthLabel";
+import Button from "@/components/Button";
 import EmploymentStatus from "@/components/EmploymentStatus";
 import { socialLinks } from "@/data/social";
 
@@ -11,9 +14,9 @@ export default function ContactFooter() {
           <p className="text-white/40 text-sm tracking-widest uppercase mb-3">— Abyss reached —</p>
           <h3 className="text-3xl font-bold text-white mb-4">Let&apos;s work together</h3>
           <p className="text-white/60 mb-8 max-w-sm">You&apos;ve made it to the bottom. If you&apos;re still here, we should probably talk.</p>
-          <a href="mailto:billyhkaufman@gmail.com" className="btn-cta clip-tr-lg px-8 py-4 font-bold text-lg">
+          <Button variant="cta-lg" href="mailto:billyhkaufman@gmail.com">
             Get in touch
-          </a>
+          </Button>
         </div>
 
         <div className="flex flex-col gap-5 md:items-end">

--- a/src/components/HeroContent.tsx
+++ b/src/components/HeroContent.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import Link from "next/link";
 import { motion } from "framer-motion";
 import { useEffect, useRef, useState } from "react";
 import { socialLinks } from "@/data/social";
 import { PARTICLE_COLORS } from "@/constants/colors";
 import ResumeButton from "@/components/ResumeButton";
+import Button from "@/components/Button";
 
 const TITLES = [
   "Software Engineer",
@@ -285,19 +285,16 @@ export default function HeroContent() {
 
       <motion.div variants={item} className="flex flex-wrap gap-3 mb-7">
         <ResumeButton />
-        <a
-          href="mailto:billyhkaufman@gmail.com"
-          className="clip-bl px-5 py-2.5 bg-white/8 hover:bg-white/15 text-white font-semibold border border-white/15 transition-colors text-sm"
-        >
+        <Button variant="secondary" href="mailto:billyhkaufman@gmail.com">
           Hire Me
-        </a>
-        <Link
+        </Button>
+        <Button
+          variant="secondary"
           href="#about"
           onClick={(e) => { e.preventDefault(); document.getElementById("about")?.scrollIntoView({ behavior: "smooth" }); }}
-          className="clip-bl px-5 py-2.5 bg-white/8 hover:bg-white/15 text-white font-semibold border border-white/15 transition-colors text-sm"
         >
           About Me
-        </Link>
+        </Button>
       </motion.div>
 
       <motion.div variants={item} className="flex gap-5">

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -270,30 +270,47 @@ export default function ProjectsGallery() {
     window.scrollTo({ top: Math.max(0, target), behavior: "smooth" });
   };
 
-  // On resize, scrollYProgress recalculates (viewport height changed) which can shift
-  // activeIdx. Capture the active project at resize start and restore it once settled.
+  // Restore scroll to the active project after a resize burst settles.
+  // null  = burst not started yet
+  // -1    = user was outside the section — skip restoration (handles iOS address-bar events)
+  // >= 0  = project index to restore
   useEffect(() => {
-    const resizeTarget = { idx: -1 };
+    let capturedIdx: number | null = null;
     let timeout: ReturnType<typeof setTimeout>;
+
+    const isViewportInsideSection = () => {
+      const el = sectionRef.current;
+      if (!el) return false;
+      const top = el.getBoundingClientRect().top + window.scrollY;
+      return window.scrollY >= top && window.scrollY + window.innerHeight <= top + el.offsetHeight;
+    };
+
     const onResize = () => {
-      if (resizeTarget.idx === -1) resizeTarget.idx = activeIdxRef.current;
-      isResizing.current = true; // freeze activeIdx while viewport is changing
+      if (capturedIdx === null) {
+        capturedIdx = isViewportInsideSection() ? activeIdxRef.current : -1;
+      }
+      isResizing.current = true;
       clearTimeout(timeout);
       timeout = setTimeout(() => {
-        const el = sectionRef.current;
-        if (el) {
-          const top = el.getBoundingClientRect().top + window.scrollY;
-          const h = el.offsetHeight;
-          const target = top + ((resizeTarget.idx + 0.4) / N) * Math.max(h - window.innerHeight, 0);
-          window.scrollTo({ top: Math.max(0, target), behavior: "instant" });
+        if (capturedIdx !== null && capturedIdx >= 0) {
+          const el = sectionRef.current;
+          if (el) {
+            const top = el.getBoundingClientRect().top + window.scrollY;
+            const h = el.offsetHeight;
+            window.scrollTo({
+              top: Math.max(0, top + ((capturedIdx + 0.4) / N) * Math.max(h - window.innerHeight, 0)),
+              behavior: "instant",
+            });
+          }
         }
-        resizeTarget.idx = -1;
-        isResizing.current = false; // resume normal scroll tracking
+        capturedIdx = null;
+        isResizing.current = false;
       }, 200);
     };
+
     window.addEventListener("resize", onResize);
     return () => { window.removeEventListener("resize", onResize); clearTimeout(timeout); };
-  }, []); // empty deps — only refs (sectionRef, activeIdxRef) and constant N
+  }, []);
 
 
   return (

--- a/src/components/ResumeButton.tsx
+++ b/src/components/ResumeButton.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { RESUME_URL } from "@/data/bio";
 import { useScrollLock } from "@/hooks/useScrollLock";
+import Button from "@/components/Button";
 
 
 export default function ResumeButton() {
@@ -23,12 +24,9 @@ export default function ResumeButton() {
 
   return (
     <>
-      <button
-        onClick={() => setOpen(true)}
-        className="btn-cta clip-tr-bl px-5 py-2.5 font-semibold text-sm cursor-pointer"
-      >
+      <Button variant="primary" onClick={() => setOpen(true)}>
         View Resume
-      </button>
+      </Button>
 
       {open && createPortal(
         <div

--- a/src/components/SeaFloorHop.tsx
+++ b/src/components/SeaFloorHop.tsx
@@ -212,7 +212,8 @@ export default function SeaFloorHop() {
       stateRef.current = "playing";
       fishVY.current = JUMP_V;
     } else if (stateRef.current === "playing") {
-      fishVY.current = JUMP_V;
+      // Only jump when on or near the floor — prevents double jump
+      if (fishY.current >= FLOOR_Y - FISH_R - 1) fishVY.current = JUMP_V;
     } else if (stateRef.current === "dead") {
       reset();
       stateRef.current = "playing";

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -3,8 +3,7 @@ import { URLS } from "@/constants/urls";
 export type Client = {
   title: string;
   description: string;
-  domain?: string;  // display label
-  url?: string;     // full href — overrides https://${domain} when set
+  url?: string;      // if set, shown as a link in the card modal
   accentColor: string;
   logoBg?: string;
 };
@@ -48,14 +47,12 @@ export const clientsData: Client[] = [
   },
   {
     title: "Johnson & Johnson",
-    description: "Built custom JavaScript behavior tracking across J&J's worldwide Google Tag Manager accounts, touching tracking mechanisms across multiple global regions.",
-    url: URLS.jnj,
+    description: "Built custom JavaScript behavior tracking across Neutrogena's worldwide Google Tag Manager accounts, touching tracking mechanisms across multiple global regions. Neutrogena has since spun off into Kenvue.",
     accentColor: "#cc0000",
   },
   {
     title: "Domino's",
     description: "Contributed to the Slice the Price card web application, a promotional experience built for one of the world's most iconic pizza brands.",
-    domain: "slicethepricecard.com",
     accentColor: "#006491",
   },
 ];

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -111,12 +111,12 @@ export const experienceData: ExperienceEntry[] = [
     description1:
       "After years of studying classical percussion, earned a doctorate in music performance at one of the country's top conservatories.",
     description2:
-      "My dissertation applied project management frameworks to high-stakes performance auditions. Developing that kind of rigorous, structured mindset was about to influence me in a major way...",
+      "My dissertation applied project management frameworks to high-stakes audition performance. Developing that kind of rigorous, structured mindset was about to influence me in a major way...",
     link: {
       label: "Read the dissertation",
       href: URLS.dissertation,
     },
-    dateRange: "2017 – 2020",
+    dateRange: "2014 – 2020",
     logoSrc: "/images/um-logo.jpg",
     accentColor: "#dce5df",
     logoFit: "contain",

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -8,15 +8,18 @@ export const skillsData: SkillCategory[] = [
     heading: "Frontend",
     skills: [
       "React", "Next.js", "TypeScript", "JavaScript",
-      "Tailwind CSS", "CSS / SCSS", "Framer Motion", "GSAP",
+      "Redux", "Tailwind CSS", "CSS / SCSS", "Framer Motion", "GSAP",
       "Three.js", "React Three Fiber", "Responsive Design",
+      "Complex State Management", "Authentication Solutions",
     ],
   },
   {
     heading: "Backend",
     skills: [
-      "Python", "Django", "Node.js", "REST API Design",
-      "PostgreSQL", "GraphQL", "WebSockets", "Auth / OAuth",
+      "Python", "Django", "Fastify", "Node.js",
+      "REST API Design", "OpenAPI", "tRPC", "GraphQL",
+      "PostgreSQL", "Redis", "WebSockets", "Auth / OAuth",
+      "Endpoint Optimization at Scale", "asyncio",
     ],
   },
   {
@@ -30,7 +33,8 @@ export const skillsData: SkillCategory[] = [
     heading: "AI & Modern Tooling",
     skills: [
       "Claude / Claude Code", "Cursor", "AWS Bedrock",
-      "Prompt Engineering", "LLM Integration",
+      "MCP (Model Context Protocol)", "Prompt Engineering",
+      "LLM Integration", "Multi-Context AI Applications",
     ],
   },
   {

--- a/src/data/tools.ts
+++ b/src/data/tools.ts
@@ -4,8 +4,8 @@ export type ToolCategory = {
 };
 
 export const toolsData: ToolCategory[] = [
-  { title: "IDE",              items: ["Cursor", "VS Code"] },
-  { title: "Version Control",  items: ["Git", "GitHub", "GitLab", "Bitbucket"] },
-  { title: "Project Mgmt",     items: ["Jira", "Linear", "Asana", "ClickUp"] },
-  { title: "Design",           items: ["Figma", "Storybook"] },
+  { title: "IDE",             items: ["VS Code", "Cursor", "PyCharm"] },
+  { title: "Version Control", items: ["Git", "GitHub", "GitLab", "Bitbucket"] },
+  { title: "Project Mgmt",    items: ["Jira", "Agile", "Asana", "ClickUp"] },
+  { title: "Design",          items: ["Figma", "Storybook", "draw.io"] },
 ];


### PR DESCRIPTION
## Summary
- **Data/copy updates**: expanded skills (Redux, Fastify, tRPC, Redis, MCP, etc.), tools (PyCharm, draw.io, Agile), experience date fix (UM 2014-2020), client card descriptions (J&J to Neutrogena/Kenvue, domain decoupled from URL)
- **Button component**: single Button.tsx with primary / secondary / cta-lg variants -- all buttons centralized with consistent whileTap tap scale; replaces inline JSX across HeroContent, AboutSection, ResumeButton, ContactFooter
- **Scroll hijack fix**: resize handler in ProjectsGallery now checks if viewport is inside the section before restoring scroll -- fixes mobile address-bar jump and desktop resize jumping into section from outside
- **Game fix**: SeaFloorHop double-jump prevention -- only allows jump when fish is on or near the floor

## Test plan
- [ ] View Resume, Hire Me (x2), About Me, Get in touch -- all show tap scale on click
- [ ] Resize while scrolled above/below projects section -- should not jump into section
- [ ] Resize while inside projects section -- should restore current project position
- [ ] Mobile: scroll past projects to bottom of page, address bar toggle should not jump back
- [ ] SeaFloorHop: confirm fish cannot double-jump mid-air
- [ ] Client card modals: URL shown as derived hostname (no manual domain field)
- [ ] J&J and Dominos cards: no link shown