### PR TITLE
UX details, depth system overhaul, console warning fixes

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${raleway.variable} h-full antialiased`}>
+    <html lang="en" className={`${raleway.variable} h-full antialiased relative`}>
       <body className="min-h-full flex flex-col bg-slate-950 text-white">
         <DepthScrollProvider>
           <NavBar />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,8 @@ import HudBottomBar from "@/components/ocean/HudBottomBar";
 import ZoneColorSync from "@/components/ocean/ZoneColorSync";
 import HudBrackets from "@/components/HudBrackets";
 import IntroLock from "@/components/IntroLock";
+import ScrollHint from "@/components/ScrollHint";
+import DepthScrollProvider from "@/context/DepthScrollContext";
 import "./globals.css";
 
 const raleway = Raleway({
@@ -28,14 +30,17 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${raleway.variable} h-full antialiased`}>
       <body className="min-h-full flex flex-col bg-slate-950 text-white">
-        <NavBar />
-        <ZoneColorSync />
-        <DepthGauge />
-        <HudSensorPanel />
-        <HudBottomBar />
-        <HudBrackets />
-        <IntroLock />
-{children}
+        <DepthScrollProvider>
+          <NavBar />
+          <ZoneColorSync />
+          <DepthGauge />
+          <HudSensorPanel />
+          <HudBottomBar />
+          <HudBrackets />
+          <IntroLock />
+          <ScrollHint />
+          {children}
+        </DepthScrollProvider>
       </body>
     </html>
   );

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -98,7 +98,6 @@ function HeadshotCard() {
           alt="Headshot of Billy Kaufman"
           width={360}
           height={360}
-          style={{ height: "auto" }}
           priority
           className="rounded-2xl object-cover shadow-xl ring-1 ring-white/15 opacity-90 block"
         />

--- a/src/components/ExperienceTimeline.tsx
+++ b/src/components/ExperienceTimeline.tsx
@@ -139,6 +139,7 @@ function TimelineRow({
             alt={entry.institutionName}
             width={40}
             height={40}
+            priority={index < 4}
             className={`w-full h-full ${entry.logoFit === "contain" ? "object-contain" : "object-cover"} ${entry.logoPadding ?? ""}`}
           />
         ) : (

--- a/src/components/ExperienceTimeline.tsx
+++ b/src/components/ExperienceTimeline.tsx
@@ -139,7 +139,7 @@ function TimelineRow({
             alt={entry.institutionName}
             width={40}
             height={40}
-            priority={index < 4}
+            priority
             className={`w-full h-full ${entry.logoFit === "contain" ? "object-contain" : "object-cover"} ${entry.logoPadding ?? ""}`}
           />
         ) : (

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect } from "react";
 import { useScrollLock } from "@/hooks/useScrollLock";
 import { useHudVisible } from "@/hooks/useHudVisible";
-import { motion, AnimatePresence, useScroll, useTransform, useMotionValueEvent } from "framer-motion";
+import { motion, AnimatePresence, useTransform, useMotionValueEvent } from "framer-motion";
+import { useDepthScroll } from "@/context/DepthScrollContext";
 import { socialLinks } from "@/data/social";
 
 const navLinks = [
@@ -240,7 +241,7 @@ export default function NavBar() {
   };
 
   // Live depth — same transform as DepthGauge
-  const { scrollYProgress } = useScroll();
+  const { scrollYProgress } = useDepthScroll();
   const depthMV = useTransform(scrollYProgress, [...DEPTH_STOPS], [...DEPTH_VALS]);
   useMotionValueEvent(depthMV, "change", (v) => setDepth(Math.round(v)));
 
@@ -279,6 +280,7 @@ export default function NavBar() {
           <button
             onClick={() => {
               scrollTo("#home");
+              setMobileOpen(false);
               setMobileBkActive(true);
               setTimeout(() => setMobileBkActive(false), 450);
             }}

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -233,17 +233,13 @@ export default function ProjectsGallery() {
 
   const springProgress = useSpring(scrollYProgress, { stiffness: 100, damping: 30 });
 
-  const [sectionDone, setSectionDone] = useState(false);
-  // Refs used by the scroll listener and resize handler — declared first to avoid
-  // forward-reference confusion even though closures capture them by identity.
   const activeIdxRef = useRef(0);
   const isResizing   = useRef(false);
 
-  // Single listener: tracks active project and section-done flag.
-  // Maps scrollYProgress [0,1] → [0,N) via Math.floor(v * (N - 0.0001)).
+  // Maps scrollYProgress [0,1] → [0,N) to pick the active project.
   useMotionValueEvent(scrollYProgress, "change", (v) => {
-    if (isResizing.current) return; // freeze during resize — handler restores position
-    setSectionDone(v >= 0.999);
+    if (isResizing.current) return;
+
     const next = Math.floor(v * (N - 0.0001));
     activeIdxRef.current = next;
     setActiveIdx((prev) => {
@@ -314,7 +310,7 @@ export default function ProjectsGallery() {
 
 
   return (
-    <div ref={sectionRef} style={{ height: `${N * 80}vh` }}>
+    <div ref={sectionRef} style={{ height: `${N * 30}vh`, position: "relative" }}>
       {/* ── Sticky panel ── */}
       <div
         className="sticky flex items-center overflow-hidden"
@@ -357,9 +353,8 @@ export default function ProjectsGallery() {
               transition={{ type: "spring", stiffness: 280, damping: 38, mass: 0.8 }}
             >
               {projectsData.map((p, i) => {
-                const dist = Math.abs(i - activeIdx);
                 const isActive = i === activeIdx;
-                const rowOpacity = isActive ? 1 : dist === 1 ? 0.5 : 0.18;
+                const rowOpacity = isActive ? 1 : 0.18;
                 const counter = String(i + 1).padStart(2, "0") + " / " + String(N).padStart(2, "0");
 
                 return (
@@ -435,28 +430,6 @@ export default function ProjectsGallery() {
         </div>{/* end inner panel */}
       </div>
 
-      {/* ── Mobile scroll hint — visible on first project until user scrolls ── */}
-      <AnimatePresence>
-        {!sectionDone && (
-          <motion.div
-            className="fixed bottom-6 left-1/2 -translate-x-1/2 flex flex-col items-center gap-1 z-20 md:hidden pointer-events-none"
-            initial={{ opacity: 0, y: 6 }}
-            animate={{ opacity: 1, y: [0, -5, 0] }}
-            exit={{ opacity: 0, y: 6 }}
-            transition={{ duration: 0.4, delay: 0.6, y: { duration: 2, repeat: Infinity, ease: "easeInOut", delay: 0.6 } }}
-          >
-            <span className="text-[9px] font-mono tracking-[0.2em] uppercase" style={{ color: "var(--zone-accent)", opacity: 0.5 }}>
-              scroll
-            </span>
-            <motion.span
-              className="block w-px h-5"
-              style={{ background: "linear-gradient(to bottom, var(--zone-accent), transparent)" }}
-              animate={{ scaleY: [1, 0.4, 1], opacity: [0.5, 1, 0.5] }}
-              transition={{ duration: 1.4, repeat: Infinity, ease: "easeInOut" }}
-            />
-          </motion.div>
-        )}
-      </AnimatePresence>
 
       {/* ── Description modal ── */}
       <Modal isOpen={descModal} onClose={() => setDescModal(false)}>

--- a/src/components/ScrollHint.tsx
+++ b/src/components/ScrollHint.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { motion, AnimatePresence, useMotionValueEvent } from "framer-motion";
+import { useState } from "react";
+import { useDepthScroll } from "@/context/DepthScrollContext";
+
+export default function ScrollHint() {
+  const { scrollYProgress } = useDepthScroll();
+  const [visible, setVisible] = useState(true);
+
+  useMotionValueEvent(scrollYProgress, "change", (v) => {
+    setVisible(v < 0.92);
+  });
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          className="fixed bottom-6 left-1/2 -translate-x-1/2 flex flex-col items-center gap-1 z-20 pointer-events-none"
+          initial={{ opacity: 0, y: 6 }}
+          animate={{ opacity: 1, y: [0, -5, 0] }}
+          exit={{ opacity: 0, y: 6 }}
+          transition={{
+            duration: 0.4,
+            delay: 0.6,
+            y: { duration: 2, repeat: Infinity, ease: "easeInOut", delay: 0.6 },
+          }}
+        >
+          <span
+            className="text-[9px] font-mono tracking-[0.2em] uppercase"
+            style={{ color: "var(--zone-accent)", opacity: 0.5 }}
+          >
+            scroll
+          </span>
+          <motion.span
+            className="block w-px h-5"
+            style={{ background: "linear-gradient(to bottom, var(--zone-accent), transparent)" }}
+            animate={{ scaleY: [1, 0.4, 1], opacity: [0.5, 1, 0.5] }}
+            transition={{ duration: 1.4, repeat: Infinity, ease: "easeInOut" }}
+          />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/SectionHeading.tsx
+++ b/src/components/SectionHeading.tsx
@@ -17,7 +17,7 @@ export default function SectionHeading({ title, subtitle }: { title: string; sub
   const x = useTransform(scrollYProgress, [0, 1], ["18%", "0%"]);
 
   return (
-    <div ref={ref} className="mb-10">
+    <div ref={ref} className="relative mb-10">
       {/* Perspective wrapper for 3D fold */}
       <div style={{ perspective: "900px", perspectiveOrigin: "50% 100%" }}>
         <motion.h2

--- a/src/components/ocean/DepthGauge.tsx
+++ b/src/components/ocean/DepthGauge.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { motion, useScroll, useTransform, useMotionValueEvent } from "framer-motion";
+import { motion, useTransform, useMotionValueEvent } from "framer-motion";
+import { useDepthScroll } from "@/context/DepthScrollContext";
 import { INTRO_TOTAL } from "@/components/ocean/HeroElements";
 
 
@@ -26,7 +27,7 @@ export default function DepthGauge() {
   const [show, setShow] = useState(false);
   const noIntro = useRef(false); // true = no intro played; set in useEffect
 
-  const { scrollYProgress } = useScroll();
+  const { scrollYProgress } = useDepthScroll();
   const depthMV = useTransform(scrollYProgress, [...STOPS], [...DEPTHS]);
   useMotionValueEvent(depthMV, "change", (v) => setDepth(Math.round(v)));
 

--- a/src/components/ocean/DepthLabel.tsx
+++ b/src/components/ocean/DepthLabel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { motion, useInView, useScroll, useTransform, useMotionValueEvent } from "framer-motion";
+import { motion, useInView, useTransform, useMotionValueEvent } from "framer-motion";
+import { useDepthScroll } from "@/context/DepthScrollContext";
 
 const EASE = [0.25, 0.1, 0.25, 1] as const;
 
@@ -15,7 +16,7 @@ export default function DepthLabel({ depth: _depth }: { depth: string }) {
   const [current, setCurrent] = useState(0);
 
   // Mirror the gauge — always the same value
-  const { scrollYProgress } = useScroll();
+  const { scrollYProgress } = useDepthScroll();
   const depthMV = useTransform(scrollYProgress, [...STOPS], [...DEPTHS]);
 
   useMotionValueEvent(depthMV, "change", (v) => {

--- a/src/components/ocean/HudBottomBar.tsx
+++ b/src/components/ocean/HudBottomBar.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { motion, useScroll, useTransform, useMotionValueEvent } from "framer-motion";
+import { motion, useTransform, useMotionValueEvent } from "framer-motion";
+import { useDepthScroll } from "@/context/DepthScrollContext";
 import { INTRO_TOTAL } from "@/components/ocean/HeroElements";
 
 const SECTIONS = 6;
@@ -63,7 +64,7 @@ export default function HudBottomBar() {
   const [show, setShow] = useState(false);
   const noIntro = useRef(false);
 
-  const { scrollYProgress } = useScroll();
+  const { scrollYProgress } = useDepthScroll();
   const wpMV = useTransform(scrollYProgress, [0, 1], [0, SECTIONS - 1]);
   useMotionValueEvent(wpMV, "change", (v) => setWaypoint(Math.round(v) + 1));
 

--- a/src/components/ocean/HudSensorPanel.tsx
+++ b/src/components/ocean/HudSensorPanel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { motion, useScroll, useTransform, useMotionValueEvent } from "framer-motion";
+import { motion, useTransform, useMotionValueEvent } from "framer-motion";
+import { useDepthScroll } from "@/context/DepthScrollContext";
 import { INTRO_TOTAL } from "@/components/ocean/HeroElements";
 
 
@@ -27,7 +28,7 @@ export default function HudSensorPanel() {
   const [show, setShow] = useState(false);
   const noIntro = useRef(false); // true = no intro played; set in useEffect
 
-  const { scrollYProgress } = useScroll();
+  const { scrollYProgress } = useDepthScroll();
   const depthMV = useTransform(scrollYProgress, [...STOPS], [...DEPTHS]);
   // Absolute pressure: P_atm + ρ_sw·g·d / P₀
   // ρ_sw = 1025 kg/m³, g = 9.81 m/s², P₀ = 101 325 Pa → ~1 ATM per 10.066 m

--- a/src/components/ocean/ZoneColorSync.tsx
+++ b/src/components/ocean/ZoneColorSync.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect } from "react";
-import { useScroll, useTransform, useMotionValueEvent } from "framer-motion";
+import { useTransform, useMotionValueEvent } from "framer-motion";
+import { useDepthScroll } from "@/context/DepthScrollContext";
 
 // Must stay in sync with DepthGauge.tsx scroll stops
 const STOPS = [0, 0.18, 0.38, 0.57, 0.74, 1] as const;
@@ -21,7 +22,7 @@ const COLORS = [
 export const ZONE_COLORS = COLORS;
 
 export default function ZoneColorSync() {
-  const { scrollYProgress } = useScroll();
+  const { scrollYProgress } = useDepthScroll();
 
   // Framer Motion interpolates hex colors natively
   const accent = useTransform(scrollYProgress, [...STOPS], [...COLORS]);

--- a/src/context/DepthScrollContext.tsx
+++ b/src/context/DepthScrollContext.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { createContext, useCallback, useContext, useLayoutEffect, useMemo, useRef } from "react";
+import { motionValue, MotionValue, useMotionValueEvent, useScroll } from "framer-motion";
+
+interface DepthScrollCtx {
+  scrollYProgress: MotionValue<number>;
+  freeze: (at?: number) => void;
+  unfreeze: () => void;
+}
+
+const DepthScrollContext = createContext<DepthScrollCtx | null>(null);
+
+// Wraps the full app. Provides a shared scrollYProgress MotionValue that all
+// depth-reading components subscribe to. Can be frozen (e.g. while ProjectsGallery
+// is active) so the depth display holds steady while the user browses projects.
+export default function DepthScrollProvider({ children }: { children: React.ReactNode }) {
+  const { scrollYProgress: rawProgress } = useScroll();
+
+  const displayProgress = useMemo(() => motionValue(0), []);
+  const frozenRef = useRef(false);
+
+  // Sync to actual scroll before the first paint — avoids any post-mount flicker.
+  useLayoutEffect(() => {
+    displayProgress.set(rawProgress.get());
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Keep displayProgress in sync with page scroll when not frozen.
+  useMotionValueEvent(rawProgress, "change", (v) => {
+    if (!frozenRef.current) displayProgress.set(v);
+  });
+
+  const freeze = useCallback((at?: number) => {
+    frozenRef.current = true;
+    if (at !== undefined) displayProgress.set(at);
+  }, [displayProgress]);
+
+  const unfreeze = useCallback(() => {
+    frozenRef.current = false;
+    displayProgress.set(rawProgress.get());
+  }, [rawProgress, displayProgress]);
+
+  const value = useMemo(
+    () => ({ scrollYProgress: displayProgress, freeze, unfreeze }),
+    [displayProgress, freeze, unfreeze],
+  );
+
+  return <DepthScrollContext.Provider value={value}>{children}</DepthScrollContext.Provider>;
+}
+
+/** Drop-in replacement for `useScroll()` in depth-reading components. */
+export function useDepthScroll(): { scrollYProgress: MotionValue<number> } {
+  const ctx = useContext(DepthScrollContext);
+  if (!ctx) throw new Error("useDepthScroll must be inside DepthScrollProvider");
+  return { scrollYProgress: ctx.scrollYProgress };
+}
+
+/** Used by components that need to pause depth tracking.
+ *  freeze(at?) — pass a page-level progress value to pin to, or omit to hold current. */
+export function useDepthFreeze() {
+  const ctx = useContext(DepthScrollContext);
+  if (!ctx) throw new Error("useDepthFreeze must be inside DepthScrollProvider");
+  return { freeze: ctx.freeze, unfreeze: ctx.unfreeze };
+}

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -53,6 +53,7 @@ export const clientsData: Client[] = [
   {
     title: "Domino's",
     description: "Contributed to the Slice the Price card web application, a promotional experience built for one of the world's most iconic pizza brands.",
+    url: URLS.dominos,
     accentColor: "#006491",
   },
 ];


### PR DESCRIPTION
## Summary

- **Button component** — refactored all CTAs into a single `Button` with `primary`, `secondary`, and `cta-lg` variants, centralising tap/hover behaviour
- **Depth system** — introduced `DepthScrollProvider` context with a shared `scrollYProgress` MotionValue used by all HUD components (ZoneColorSync, DepthGauge, HudSensorPanel, HudBottomBar, DepthLabel, NavBar); replaced the over-engineered freeze mechanism with natural depth tracking through the Projects section (500m → 1000m as intended by the section depth labels)
- **Global scroll hint** — moved the bouncing scroll indicator out of ProjectsGallery into a standalone `ScrollHint` component visible throughout the entire page on all screen sizes
- **ProjectsGallery UX** — reduced scroll distance per project from 80vh → 30vh; removed next-up project highlight opacity; restored Domino's URL
- **Mobile nav** — close mobile menu when tapping the BK logo in the top-left
- **Console warnings** — fixed Framer Motion non-static position warning by adding `relative` to `<html>`; marked all experience timeline logos as `priority` to resolve LCP warning; fixed Next.js Image and Framer Motion position warnings in SectionHeading and ProjectsGallery

## Test plan

- [ ] Scroll through full page — zone colors (violet → indigo → emerald) transition smoothly through Experience → Projects → Skills
- [ ] Scroll hint visible on desktop and mobile throughout entire page
- [ ] All button variants render and animate correctly (primary, secondary, cta-lg)
- [ ] Mobile nav closes when tapping BK logo
- [ ] Domino's client card links to slicethepricecard.com
- [ ] No console warnings on fresh page load (except THREE.Clock which is an upstream r3f issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)