### PR TITLE
Replace scroll-hijacked projects gallery with selection-based nav

### DIFF
--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -1,24 +1,21 @@
 "use client";
 
 import Image from "next/image";
-import { useState, useRef, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { projectsData, type Project } from "@/data/projects";
 import BannerShowcase from "./BannerShowcase";
-import { FaGithub, FaExternalLinkAlt, FaChevronLeft, FaChevronRight } from "react-icons/fa";
+import { FaGithub, FaExternalLinkAlt, FaChevronLeft, FaChevronRight, FaChevronUp, FaChevronDown } from "react-icons/fa";
 import {
   motion,
   AnimatePresence,
-  useScroll,
-  useSpring,
   useMotionValue,
   useMotionTemplate,
-  useMotionValueEvent,
+  useSpring,
 } from "framer-motion";
 import { BloombergLogo } from "./ClientLogos";
 import Modal from "./Modal";
 
 const N = projectsData.length;
-const NAV_H = 64;
 const ITEM_H = 40; // px — height of each compact (non-active) list row
 const PILL_CLS = "text-xs px-2.5 py-1 bg-blue-500/15 text-blue-300 rounded-full border border-blue-500/20";
 
@@ -224,118 +221,28 @@ export default function ProjectsGallery() {
   const [activeIdx, setActiveIdx] = useState(0);
   const [imageIdx, setImageIdx] = useState(0);
   const [descModal, setDescModal] = useState(false);
-  const sectionRef = useRef<HTMLDivElement>(null);
 
-  const { scrollYProgress } = useScroll({
-    target: sectionRef,
-    offset: ["start start", "end end"],
-  });
-
-  const springProgress = useSpring(scrollYProgress, { stiffness: 100, damping: 30 });
-
-  const [sectionDone, setSectionDone] = useState(false);
-  // Refs used by the scroll listener and resize handler — declared first to avoid
-  // forward-reference confusion even though closures capture them by identity.
-  const activeIdxRef = useRef(0);
-  const isResizing   = useRef(false);
-
-  // Single listener: tracks active project and section-done flag.
-  // Maps scrollYProgress [0,1] → [0,N) via Math.floor(v * (N - 0.0001)).
-  useMotionValueEvent(scrollYProgress, "change", (v) => {
-    if (isResizing.current) return; // freeze during resize — handler restores position
-    setSectionDone(v >= 0.999);
-    const next = Math.floor(v * (N - 0.0001));
-    activeIdxRef.current = next;
-    setActiveIdx((prev) => {
-      if (prev === next) return prev;
-      setImageIdx(0);
-      return next;
-    });
-  });
-
-  useEffect(() => { setDescModal(false); }, [activeIdx]);
+  const goTo = (idx: number) => {
+    setActiveIdx(idx);
+    setImageIdx(0);
+    setDescModal(false);
+  };
+  const goPrev = () => goTo((activeIdx - 1 + N) % N);
+  const goNext = () => goTo((activeIdx + 1) % N);
 
   const project = projectsData[activeIdx];
 
   const handlePrev = () => setImageIdx((i) => (i === 0 ? project.images.length - 1 : i - 1));
   const handleNext = () => setImageIdx((i) => (i === project.images.length - 1 ? 0 : i + 1));
 
-  // Scroll to idx + 0.4 within its scroll band (midpoint avoids boundary rounding issues).
-  const scrollToProject = (idx: number) => {
-    const el = sectionRef.current;
-    if (!el) return;
-    const top = el.getBoundingClientRect().top + window.scrollY;
-    const h = el.offsetHeight;
-    const target = top + ((idx + 0.4) / N) * Math.max(h - window.innerHeight, 0);
-    window.scrollTo({ top: Math.max(0, target), behavior: "smooth" });
-  };
-
-  // Restore scroll to the active project after a resize burst settles.
-  // null  = burst not started yet
-  // -1    = user was outside the section — skip restoration (handles iOS address-bar events)
-  // >= 0  = project index to restore
-  useEffect(() => {
-    let capturedIdx: number | null = null;
-    let timeout: ReturnType<typeof setTimeout>;
-
-    const isViewportInsideSection = () => {
-      const el = sectionRef.current;
-      if (!el) return false;
-      const top = el.getBoundingClientRect().top + window.scrollY;
-      return window.scrollY >= top && window.scrollY + window.innerHeight <= top + el.offsetHeight;
-    };
-
-    const onResize = () => {
-      if (capturedIdx === null) {
-        capturedIdx = isViewportInsideSection() ? activeIdxRef.current : -1;
-      }
-      isResizing.current = true;
-      clearTimeout(timeout);
-      timeout = setTimeout(() => {
-        if (capturedIdx !== null && capturedIdx >= 0) {
-          const el = sectionRef.current;
-          if (el) {
-            const top = el.getBoundingClientRect().top + window.scrollY;
-            const h = el.offsetHeight;
-            window.scrollTo({
-              top: Math.max(0, top + ((capturedIdx + 0.4) / N) * Math.max(h - window.innerHeight, 0)),
-              behavior: "instant",
-            });
-          }
-        }
-        capturedIdx = null;
-        isResizing.current = false;
-      }, 200);
-    };
-
-    window.addEventListener("resize", onResize);
-    return () => { window.removeEventListener("resize", onResize); clearTimeout(timeout); };
-  }, []);
-
-
   return (
-    <div ref={sectionRef} style={{ height: `${N * 80}vh` }}>
-      {/* ── Sticky panel ── */}
+    <div className="relative">
       <div
-        className="sticky flex items-center overflow-hidden"
-        style={{ top: NAV_H, height: `calc(100svh - ${NAV_H}px)` }}
+        className="flex flex-col md:flex-row w-full overflow-hidden"
+        style={{ height: "clamp(600px, 78svh, 820px)" }}
       >
-        {/* Inner panel — capped at 900px so tall viewports don't stretch the layout */}
-        <div
-          className="relative flex flex-col md:flex-row w-full overflow-hidden"
-          style={{ height: `min(calc(100svh - ${NAV_H}px), 900px)` }}
-        >
-
-        {/* Scroll progress bar — left edge */}
-        <div className="absolute left-0 top-0 bottom-0 w-0.5 z-20 overflow-hidden">
-          <motion.div
-            className="absolute inset-x-0 top-0 bottom-0 opacity-50"
-            style={{ background: "var(--zone-accent)", scaleY: springProgress, transformOrigin: "top" }}
-          />
-        </div>
 
         {/* ── LEFT: HUD Screen ── */}
-        {/* max-h-[52%] on mobile caps the HUD so the info panel always gets the rest of the viewport */}
         <div className="md:w-[55%] max-h-[52%] md:max-h-none flex items-start md:items-center justify-center p-4 md:p-10 md:pl-8 shrink-0 overflow-hidden">
           <div className="w-full">
             <HudScreen
@@ -348,18 +255,20 @@ export default function ProjectsGallery() {
           </div>
         </div>
 
-        {/* ── RIGHT: Unified project list — active item expands with full info ── */}
-        <div className="flex-1 flex flex-col px-6 md:px-8 pt-4 pb-6 md:py-10 border-t md:border-t-0 md:border-l border-white/8 overflow-hidden">
-          {/* List scrolls so active item is always at the top */}
+        {/* ── RIGHT: project list + info ── */}
+        <div className="flex-1 flex flex-col px-6 md:px-8 pt-4 pb-4 md:py-10 border-t md:border-t-0 md:border-l border-white/8 overflow-hidden">
+
+          {/* Scrolling list — active item stays at top.
+              TODO: if the project list grows to the point where it overflows this container,
+              replace this with a searchable/filterable list (search input + filtered projectsData). */}
           <div className="flex-1 min-h-0 relative overflow-hidden">
             <motion.div
               animate={{ y: -activeIdx * ITEM_H }}
               transition={{ type: "spring", stiffness: 280, damping: 38, mass: 0.8 }}
             >
               {projectsData.map((p, i) => {
-                const dist = Math.abs(i - activeIdx);
                 const isActive = i === activeIdx;
-                const rowOpacity = isActive ? 1 : dist === 1 ? 0.5 : 0.18;
+                const rowOpacity = isActive ? 1 : 0.18;
                 const counter = String(i + 1).padStart(2, "0") + " / " + String(N).padStart(2, "0");
 
                 return (
@@ -411,11 +320,11 @@ export default function ProjectsGallery() {
                         </button>
                       </div>
                     ) : (
-                      /* Compact non-active row */
+                      /* Compact non-active row — click to select */
                       <button
                         type="button"
                         style={{ height: ITEM_H, cursor: "pointer" }}
-                        onClick={() => scrollToProject(i)}
+                        onClick={() => goTo(i)}
                         className="flex w-full items-center gap-2.5 select-none text-left"
                         aria-label={`Go to project ${i + 1}: ${p.title}`}
                       >
@@ -430,33 +339,56 @@ export default function ProjectsGallery() {
               })}
             </motion.div>
           </div>
+
+          {/* ── Prev / Next navigation ── */}
+          <div
+            className="flex items-center justify-between shrink-0 pt-3"
+            style={{ borderTop: "1px solid rgba(255,255,255,0.08)" }}
+          >
+            <button
+              onClick={goPrev}
+              className="flex items-center gap-2 text-xs font-mono tracking-wider transition-colors cursor-pointer"
+              style={{ color: "var(--zone-accent)", opacity: 0.5 }}
+              onMouseEnter={e => (e.currentTarget.style.opacity = "1")}
+              onMouseLeave={e => (e.currentTarget.style.opacity = "0.5")}
+              aria-label="Previous project"
+            >
+              <FaChevronUp size={10} /> PREV
+            </button>
+
+            {/* Dot indicators */}
+            <div className="flex items-center gap-1.5">
+              {projectsData.map((_, i) => (
+                <button
+                  key={i}
+                  onClick={() => goTo(i)}
+                  aria-label={`Project ${i + 1}`}
+                  className="transition-all duration-200 rounded-full cursor-pointer"
+                  style={{
+                    width: i === activeIdx ? 16 : 4,
+                    height: 4,
+                    background: "var(--zone-accent)",
+                    opacity: i === activeIdx ? 0.9 : 0.25,
+                  }}
+                />
+              ))}
+            </div>
+
+            <button
+              onClick={goNext}
+              className="flex items-center gap-2 text-xs font-mono tracking-wider transition-colors cursor-pointer"
+              style={{ color: "var(--zone-accent)", opacity: 0.5 }}
+              onMouseEnter={e => (e.currentTarget.style.opacity = "1")}
+              onMouseLeave={e => (e.currentTarget.style.opacity = "0.5")}
+              aria-label="Next project"
+            >
+              NEXT <FaChevronDown size={10} />
+            </button>
+          </div>
+
         </div>
 
-        </div>{/* end inner panel */}
-      </div>
-
-      {/* ── Mobile scroll hint — visible on first project until user scrolls ── */}
-      <AnimatePresence>
-        {!sectionDone && (
-          <motion.div
-            className="fixed bottom-6 left-1/2 -translate-x-1/2 flex flex-col items-center gap-1 z-20 md:hidden pointer-events-none"
-            initial={{ opacity: 0, y: 6 }}
-            animate={{ opacity: 1, y: [0, -5, 0] }}
-            exit={{ opacity: 0, y: 6 }}
-            transition={{ duration: 0.4, delay: 0.6, y: { duration: 2, repeat: Infinity, ease: "easeInOut", delay: 0.6 } }}
-          >
-            <span className="text-[9px] font-mono tracking-[0.2em] uppercase" style={{ color: "var(--zone-accent)", opacity: 0.5 }}>
-              scroll
-            </span>
-            <motion.span
-              className="block w-px h-5"
-              style={{ background: "linear-gradient(to bottom, var(--zone-accent), transparent)" }}
-              animate={{ scaleY: [1, 0.4, 1], opacity: [0.5, 1, 0.5] }}
-              transition={{ duration: 1.4, repeat: Infinity, ease: "easeInOut" }}
-            />
-          </motion.div>
-        )}
-      </AnimatePresence>
+      </div>{/* end panel */}
 
       {/* ── Description modal ── */}
       <Modal isOpen={descModal} onClose={() => setDescModal(false)}>

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -5,7 +5,7 @@ import { ProjectsGallery } from "@/components/ClientOnly";
 export default function ProjectsSection() {
   return (
     <section id="projects" className="relative">
-      <div className="px-6 md:px-16 pt-24 pb-10 max-w-5xl mx-auto">
+      <div className="px-6 md:px-16 pt-24 pb-2 max-w-5xl mx-auto">
         <DepthLabel depth="~500m" />
         <SectionHeading title="Projects" subtitle="Things I've built" />
       </div>


### PR DESCRIPTION
## Summary

- Replaces the sticky `N×80vh` scroll-hijacking mechanism with a click-driven panel — visitors can scroll past the Projects section freely at any time
- Navigation via PREV/NEXT buttons, dot indicators, or clicking any project row in the list
- Removes all scroll machinery: `useScroll`, `useMotionValueEvent`, resize handler, scroll progress bar, mobile scroll hint
- Tightens the gap between the "Projects" heading and the gallery panel (`pb-10` → `pb-2`)
- Fixes outer wrapper height so tall viewports no longer show dead space above/below the panel (`clamp(600px, 78svh, 820px)`)
- Adds TODO comment to add a searchable/filterable list if the project count ever overflows the panel

## Test plan

- [ ] Click PREV / NEXT buttons to cycle through all 8 projects
- [ ] Click dot indicators to jump directly to a project
- [ ] Click a compact row in the list to select it
- [ ] Verify scrolling past the section works freely with no hijacking
- [ ] Check layout on a short viewport (~768px tall) and a tall viewport (~1200px+)
- [ ] Verify modal opens/closes from "Read more" and project changes close it

🤖 Generated with [Claude Code](https://claude.com/claude-code)