### PR TITLE
Fix Bloomberg logo overflow and Prev/Next hover-stick on mobile

### DIFF
--- a/src/components/ClientsMarquee.tsx
+++ b/src/components/ClientsMarquee.tsx
@@ -45,7 +45,7 @@ const LOGO_KEYS: LogoKey[] = [
 ];
 
 const LOGO_MAP: Record<LogoKey, React.ReactNode> = {
-  bloomberg: <BloombergLogo className="w-full max-h-8 object-contain" />,
+  bloomberg: <BloombergLogo className="h-7 w-auto max-w-full" />,
   westrock: <WestrockLogo className="max-h-20 w-full" />,
   sebpo: <SebpoLogo className="w-12 h-12" />,
   pharmacare: <PharmacareLogo className="w-full max-h-8 object-contain" />,

--- a/src/components/ProjectsGallery.tsx
+++ b/src/components/ProjectsGallery.tsx
@@ -347,10 +347,8 @@ export default function ProjectsGallery() {
           >
             <button
               onClick={goPrev}
-              className="flex items-center gap-2 text-xs font-mono tracking-wider transition-colors cursor-pointer"
-              style={{ color: "var(--zone-accent)", opacity: 0.5 }}
-              onMouseEnter={e => (e.currentTarget.style.opacity = "1")}
-              onMouseLeave={e => (e.currentTarget.style.opacity = "0.5")}
+              className="flex items-center gap-2 text-xs font-mono tracking-wider cursor-pointer opacity-50 hover:opacity-100 active:opacity-100 transition-opacity"
+              style={{ color: "var(--zone-accent)" }}
               aria-label="Previous project"
             >
               <FaChevronUp size={10} /> PREV
@@ -376,10 +374,8 @@ export default function ProjectsGallery() {
 
             <button
               onClick={goNext}
-              className="flex items-center gap-2 text-xs font-mono tracking-wider transition-colors cursor-pointer"
-              style={{ color: "var(--zone-accent)", opacity: 0.5 }}
-              onMouseEnter={e => (e.currentTarget.style.opacity = "1")}
-              onMouseLeave={e => (e.currentTarget.style.opacity = "0.5")}
+              className="flex items-center gap-2 text-xs font-mono tracking-wider cursor-pointer opacity-50 hover:opacity-100 active:opacity-100 transition-opacity"
+              style={{ color: "var(--zone-accent)" }}
               aria-label="Next project"
             >
               NEXT <FaChevronDown size={10} />


### PR DESCRIPTION
## Summary
- **#35**: Bloomberg SVG logo overflows HUD brackets at larger sizes — switched from `w-full object-contain` to `h-7 w-auto max-w-full` (inline SVGs ignore `object-contain`, so explicit height + auto width is needed)
- **#34**: Prev/Next buttons use `onMouseEnter`/`onMouseLeave` to toggle opacity, which sticks in the "hover" state after a tap on mobile — replaced with Tailwind `opacity-50 hover:opacity-100 active:opacity-100` which correctly resets after touch

## Test plan
- [ ] Bloomberg logo stays within HUD brackets at all viewport sizes
- [ ] Prev/Next buttons dim after hovering away on desktop
- [ ] Prev/Next buttons do not stay bright after tapping on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)